### PR TITLE
Use strings.Replace instead of strings.ReplaceAll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,15 +47,10 @@ REST_GOPATH = $(GOPATH):$(CVL_GOPATH):$(TOPDIR):$(REST_DIST_DIR)
 
 #$(info REST_SRCS = $(REST_SRCS) )
 
-all: build-deps apt-deps pip-deps pip2-deps cli golang go-deps go-patch rest-server
+all: build-deps apt-deps pip-deps pip2-deps cli go-deps go-patch rest-server
 
 build-deps:
 	mkdir -p $(BUILD_DIR)
-
-golang:
-	wget https://dl.google.com/go/go1.12.6.linux-amd64.tar.gz
-	tar -zxvf go1.12.6.linux-amd64.tar.gz
-	sudo mv go /usr/local/go1.12
 
 go-deps: $(GO_DEPS_LIST)
 apt-deps: $(APT_DEPS_LIST)
@@ -89,14 +84,14 @@ $(REST_BIN): $(REST_SRCS)
 	$(MAKE) -C src/cvl/schema
 	$(MAKE) -C models/yang
 	$(MAKE) -C models
-	GOPATH=$(REST_GOPATH) /usr/local/go1.12/bin/go build -o $@ $(TOPDIR)/src/rest/main/main.go
+	GOPATH=$(REST_GOPATH) /usr/local/go/bin/go build -o $@ $(TOPDIR)/src/rest/main/main.go
 
 codegen:
 	$(MAKE) -C models
 
 go-patch:
 	cp $(TOPDIR)/ygot-modified-files/* /tmp/go/src/github.com/openconfig/ygot/ytypes/
-	/usr/local/go1.12/bin/go install -v -gcflags "-N -l" /tmp/go/src/github.com/openconfig/ygot/ygot
+	/usr/local/go/bin/go install -v -gcflags "-N -l" /tmp/go/src/github.com/openconfig/ygot/ygot
 
 
 install:

--- a/src/cvl/Makefile
+++ b/src/cvl/Makefile
@@ -1,5 +1,5 @@
 all: precheck deps schema tests
-GO=/usr/local/go1.12/bin/go
+GO=/usr/local/go/bin/go
 SRC_FILES=$(wildcard *.go)
 TOP_DIR := $(abspath ../..)
 GOFLAGS:=

--- a/src/cvl/tests/Makefile
+++ b/src/cvl/tests/Makefile
@@ -1,7 +1,7 @@
 SRC_FILES=$(wildcard *.go)
 OUT=$(patsubst %.go, %, $(SRC_FILES)) 
 TOPDIR := $(abspath ../../..)
-GO=/usr/local/go1.12/bin/go
+GO=/usr/local/go/bin/go
 GOPATH = $(TOPDIR):$(shell go env GOPATH)
 
 all:tests

--- a/src/rest/server/handler.go
+++ b/src/rest/server/handler.go
@@ -93,8 +93,8 @@ func getPathForTranslib(r *http.Request) string {
 	//    name value mapping is provided by mux.Vars() API
 	//    "acl-set{name}{type}" becomes "acl-set[name=TEST][type=ACL_IPV4]"
 	path = trimRestconfPrefix(path)
-	path = strings.ReplaceAll(path, "={", "{")
-	path = strings.ReplaceAll(path, "},{", "}{")
+	path = strings.Replace(path, "={", "{", -1)
+	path = strings.Replace(path, "},{", "}{", -1)
 
 	for k, v := range vars {
 		restStyle := fmt.Sprintf("{%v}", k)

--- a/src/translib/acl_app.go
+++ b/src/translib/acl_app.go
@@ -924,7 +924,7 @@ func (app *AclApp) getAclBindingInfoForInterfaceData(d *db.DB, intfData *ocbinds
 	if direction == "INGRESS" {
 		if intfData.IngressAclSets != nil && len(intfData.IngressAclSets.IngressAclSet) > 0 {
 			for ingressAclSetKey, _ := range intfData.IngressAclSets.IngressAclSet {
-				aclName := strings.ReplaceAll(strings.ReplaceAll(ingressAclSetKey.SetName, " ", "_"), "-", "_")
+				aclName := strings.Replace(strings.Replace(ingressAclSetKey.SetName, " ", "_", -1), "-", "_", -1)
 				aclType := ingressAclSetKey.Type.ΛMap()["E_OpenconfigAcl_ACL_TYPE"][int64(ingressAclSetKey.Type)].Name
 				aclKey := aclName + "_" + aclType
 
@@ -947,7 +947,7 @@ func (app *AclApp) getAclBindingInfoForInterfaceData(d *db.DB, intfData *ocbinds
 	} else if direction == "EGRESS" {
 		if intfData.EgressAclSets != nil && len(intfData.EgressAclSets.EgressAclSet) > 0 {
 			for egressAclSetKey, _ := range intfData.EgressAclSets.EgressAclSet {
-				aclName := strings.ReplaceAll(strings.ReplaceAll(egressAclSetKey.SetName, " ", "_"), "-", "_")
+				aclName := strings.Replace(strings.Replace(egressAclSetKey.SetName, " ", "_", -1), "-", "_", -1)
 				aclType := egressAclSetKey.Type.ΛMap()["E_OpenconfigAcl_ACL_TYPE"][int64(egressAclSetKey.Type)].Name
 				aclKey := aclName + "_" + aclType
 
@@ -1695,7 +1695,7 @@ func getAclKeysFromStrKey(aclKey string, aclType string) (string, ocbinds.E_Open
 }
 
 func getAclKeyStrFromOCKey(aclname string, acltype ocbinds.E_OpenconfigAcl_ACL_TYPE) string {
-	aclN := strings.ReplaceAll(strings.ReplaceAll(aclname, " ", "_"), "-", "_")
+	aclN := strings.Replace(strings.Replace(aclname, " ", "_", -1), "-", "_", -1)
 	aclT := acltype.ΛMap()["E_OpenconfigAcl_ACL_TYPE"][int64(acltype)].Name
 	return aclN + "_" + aclT
 }


### PR DESCRIPTION
strings.ReplaceAll was added as a new API in Go 1.12. However, the slave
Docker image currently uses Go 1.11, which doesn't have support for the
ReplaceAll method.

This change replaces all occurrences of strings.ReplaceAll with
strings.Replace, and removing the necessity to download a new version of
Go.

Signed-off-by: Nirenjan Krishnan <Nirenjan.Krishnan@dell.com>