### PR TITLE
Fix: Incorrect LLDP neighbor TTL

### DIFF
--- a/src/CLI/renderer/templates/lldp_neighbor_show.j2
+++ b/src/CLI/renderer/templates/lldp_neighbor_show.j2
@@ -12,7 +12,6 @@
 {% for v in desc %}
 {{'                  '}}{{v}}
 {% endfor %}
-{{'    TTL:          '}}{{value['state']['ttl']}}
 {% for cap in  value['capabilities']['capability'] %}
 {%  if cap['state']['enabled'] == true %}
 {%  set en = 'ON' %}
@@ -24,7 +23,7 @@
 {% endfor %}
 {{'  Port'}}
 {{'    PortID:       '}}{{value['state']['port_id']}}
-{{'    PortDescr:    '}}{{value['state']['port_description']}}   
+{{'    PortDescr:    '}}{{value['state']['port_description']}}
 {{'-----------------------------------------------------------'}}
 {% endfor %}
 

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -270,12 +270,7 @@ func (app *lldpApp) getLldpNeighInfoFromInternalMap(ifName *string, ifInfo *ocbi
                 *sdesc = value
                 ngInfo.State.SystemDescription = sdesc
             case LLDP_REMOTE_REM_TIME:
-                ttlVal , err:=strconv.Atoi(value)
-                if err == nil  {
-                    ttlPtr := new(uint16)
-                    *ttlPtr = uint16(ttlVal)
-                    ngInfo.State.Ttl = ttlPtr
-                }
+            /* Ignore Remote System time */
             case LLDP_REMOTE_PORT_ID:
                 remPortIdPtr := new(string)
                 *remPortIdPtr = value


### PR DESCRIPTION
* Remove the TTL information from CLI and GNMI output because
  LLDP neighbor TTL information is currently not stored in appDB.

Signed-off-by: Garrick He <garrick_he@dell.com>