### PR TITLE
add xml and jinja template for mgmt vrf

### DIFF
--- a/src/CLI/actioner/sonic-cli-vrf.py
+++ b/src/CLI/actioner/sonic-cli-vrf.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+###########################################################################
+#
+# Copyright 2019 Dell, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+###########################################################################
+
+import sys
+import time
+import json
+import collections
+import re
+import ast
+import openconfig_acl_client
+from rpipe_utils import pipestr
+from openconfig_acl_client.rest import ApiException
+from scripts.render_cli import show_cli_output
+
+import urllib3
+urllib3.disable_warnings()
+
+plugins = dict()
+
+def register(func):
+    """Register sdk client method as a plug-in"""
+    plugins[func.__name__] = func
+    return func
+
+
+def call_method(name, args):
+    method = plugins[name]
+    return method(args)
+
+def generate_body(func, args):
+    body = None
+    # Get the all vrfs.
+    if func.__name__ == 'get_list_openconfig_network_instance_network_instances_network_instance':
+       keypath = []
+
+    # Get a specific vrf. 
+    elif func.__name__ == 'get_openconfig_network_instance_network_instances_network_instance':
+       keypath = [ args[0] ]
+
+    # Configure management vrf. maybe just set mgmt here without args[0] 
+    elif func.__name__ == 'patch_openconfig_network_instance_network_instances_network_instance' :
+       keypath = [ args[0] args[1] args[2] ]
+       body = { "openconfig-network-instance:config": {
+                   "name": args[0],
+                   "type": args[1],
+                   "enabled": args[2]
+                   "description": ""
+                 }
+              }
+
+    # Delete management vrf.
+    elif func.__name__ == 'delete_openconfig_network_instance_network_instances_network_instance':
+       keypath = [ args[0] args[1] args[2] ]
+       body = { "openconfig-network-instance:config": {
+                   "name": args[0],
+                   "type": args[1],
+                   "enabled": args[2]
+                   "description": ""
+                 }
+              }
+    
+    else:
+        body = {}
+
+    if body is not None:
+        body = json.dumps(body,ensure_ascii=False, indent=4, separators=(',', ':'))
+        return keypath, ast.literal_eval(body)
+    else:
+        return keypath, body
+
+
+def run(func, args):
+
+    c = openconfig_network_instance_client.Configuration()
+    c.verify_ssl = False
+    aa = openconfig_network_instance_client.OpenconfigNetworkInstanceApi(api_client=openconfig_network_instance_client.ApiClient(configuration=c))
+
+    # create a body block
+    keypath, body = generate_body(func, args)
+
+    try:
+        if body is not None:
+           api_response = getattr(aa,func.__name__)(*keypath, body=body)
+        else :
+           api_response = getattr(aa,func.__name__)(*keypath)
+
+        if api_response is None:
+            print ("Success")
+        else:
+            response = api_response.to_dict()
+            if 'openconfig_network_instancenetwork_instance' in response.keys():
+                value = response['openconfig_network_instancenetwork_instance']
+                if value is None:
+                    print("Success")
+                else:
+                    print ("Failed")
+            else:
+                print("Failed")
+
+    except ApiException as e:
+        print("Exception when calling OpenconfigNetworkInstanceApi->%s : %s\n" %(func.__name__, e))
+        if e.body != "":
+            body = json.loads(e.body)
+            if "ietf-restconf:errors" in body:
+                 err = body["ietf-restconf:errors"]
+                 if "error" in err:
+                     errList = err["error"]
+
+                     errDict = {}
+                     for dict in errList:
+                         for k, v in dict.iteritems():
+                              errDict[k] = v
+
+                     if "error-message" in errDict:
+                         print "%Error: " + errDict["error-message"]
+                         return
+                     print "%Error: Transaction Failure"
+                     return
+            print "%Error: Transaction Failure"
+
+if __name__ == '__main__':
+
+    pipestr().write(sys.argv)
+    #pdb.set_trace()
+    func = eval(sys.argv[1], globals(), openconfig_network_instance_client.OpenconfigNetworkInstanceApi.__dict__)
+    run(func, sys.argv[2:])
+                                                                                          

--- a/src/CLI/actioner/sonic-cli-vrf.py
+++ b/src/CLI/actioner/sonic-cli-vrf.py
@@ -20,12 +20,9 @@
 import sys
 import time
 import json
-import collections
-import re
 import ast
-import openconfig_acl_client
-from rpipe_utils import pipestr
-from openconfig_acl_client.rest import ApiException
+import openconfig_network_instance_client
+from  openconfig_network_instance_client.rest import ApiException
 from scripts.render_cli import show_cli_output
 
 import urllib3

--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -23,12 +23,12 @@ limitations under the License.
     http://www.dellemc.com/sonic/XMLSchema/clish.xsd"
     >
     <VIEW name="enable-view">
-      <COMMAND name="show vrf" help="Show vrf information">
+      <COMMAND name="show ip vrf" help="Show vrf information">
         <ACTION> 
           python $SONIC_CLI_ROOT/openconfig_network_instance_api.py get_list_openconfig_network_instance_network_instances_network_instance show_mgmt_vrf.j2
         </ACTION>
       </COMMAND>
-      <COMMAND name="show vrf management" help="Show management vrf information">
+      <COMMAND name="show ip vrf management" help="Show management vrf information">
         <ACTION> 
           python $SONIC_CLI_ROOT/openconfig_network_instance_api.py get_openconfig_network_instance_network_instances_network_instance "mgmt" show_mgmt_vrf.j2
         </ACTION>
@@ -37,16 +37,16 @@ limitations under the License.
 
     <VIEW name="configure-view">
     <!-- vrf configuration commands -->
-    <COMMAND name="vrf" help="vrf instance configuration"/>
-      <COMMAND name="vrf management" help="management vrf configuration" mode="subcommand" ptype="SUBCOMMAND">
+    <COMMAND name="ip vrf" help="vrf instance configuration"/>
+      <COMMAND name="ip vrf management" help="management vrf configuration" mode="subcommand" ptype="SUBCOMMAND">
         <ACTION> 
           python $SONIC_CLI_ROOT/openconfig_network_instance_api.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" true&#xA; 
         </ACTION> 
       </COMMAND>
     
     <!-- no vrf commands -->
-    <COMMAND name="no vrf" help="Delete vrf instance"/>
-      <COMMAND name="no vrf management" help="Delete management vrf" mode="subcommand" ptype="SUBCOMMAND">
+    <COMMAND name="no ip vrf" help="Delete vrf instance"/>
+      <COMMAND name="no ip vrf management" help="Delete management vrf" mode="subcommand" ptype="SUBCOMMAND">
         <ACTION> 
           python $SONIC_CLI_ROOT/openconfig_network_instance_api.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" true&#xA;  
         </ACTION>

--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2019 Dell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<CLISH_MODULE
+    xmlns="http://www.dellemc.com/sonic/XMLSchema"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+    xsi:schemaLocation="http://www.dellemc.com/sonic/XMLSchema
+    http://www.dellemc.com/sonic/XMLSchema/clish.xsd"
+    >
+    <VIEW name="enable-view">
+      <COMMAND name="show vrf" help="Show vrf information">
+        <ACTION> 
+          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py get_list_openconfig_network_instance_network_instances_network_instance show_mgmt_vrf.j2
+        </ACTION>
+      </COMMAND>
+      <COMMAND name="show vrf management" help="Show management vrf information">
+        <ACTION> 
+          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py get_openconfig_network_instance_network_instances_network_instance "mgmt" show_mgmt_vrf.j2
+        </ACTION>
+      </COMMAND>
+    </VIEW>
+
+    <VIEW name="configure-view">
+    <!-- vrf configuration commands -->
+    <COMMAND name="vrf" help="vrf instance configuration"/>
+      <COMMAND name="vrf management" help="management vrf configuration" mode="subcommand" ptype="SUBCOMMAND">
+        <ACTION> 
+          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" true&#xA; 
+        </ACTION> 
+      </COMMAND>
+    
+    <!-- no vrf commands -->
+    <COMMAND name="no vrf" help="Delete vrf instance"/>
+      <COMMAND name="no vrf management" help="Delete management vrf" mode="subcommand" ptype="SUBCOMMAND">
+        <ACTION> 
+          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" true&#xA;  
+        </ACTION>
+      </COMMAND>
+
+    </VIEW>
+
+</CLISH_MODULE>

--- a/src/CLI/renderer/templates/show_vrf.j2
+++ b/src/CLI/renderer/templates/show_vrf.j2
@@ -1,0 +1,13 @@
+{{'----------------------------------------------------------------'}}
+{{'VRF-NAME'.ljust(20)}}{{'INTERFACES'}}
+{% if json_output and 'openconfig-network-instance' in json_output -%}
+{% set inst_info = json_output['openconfig-network-instance'] %}
+{% set state = inst_info['state'] %}
+{% if state['name'] == 'mgmt' %}
+{% if state['type'] == 'L3VRF' %}
+{% if state['enabled'] == true %}
+{{ state['name'] }}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
Add 3 files for management vrf configuration from CLI.
src/CLI/actioner/sonic-cli-mgmt-vrf.py
src/CLI/clitree/cli-xml/mgmt_vrf.xml
src/CLI/renderer/templates/show_mgmt_vrf.j2

The management HLD pull request is at
https://github.com/project-arlo/SONiC/pull/28/files

output of the CLI on the switch
..................................................................
onic(config)#
  end        Exit to the exec Mode
  exit       Exit from current mode
  interface  Select an interface
  ip         Global IP configuration subcommands
  no         To delete / disable commands in config mode
  vrf        vrf instance configuration

sonic(config)# vrf
  management  management vrf configuration

sonic(config)# do show
  interface  Show Interface info
  ip         show IP commands
  lldp       Show lldp information
  platform   Show platform information
  system     Show system information
  vrf        Show vrf information

sonic(config)# do show vrf
  management  Show management vrf information
  <cr>

sonic(config)# do show vrf

