### PR TITLE
Add SONiC Host Service package and infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ GO_DEPS_LIST = github.com/gorilla/mux \
                github.com/antchfx/jsonquery \
                github.com/antchfx/xmlquery \
                github.com/facette/natsort \
-	             github.com/philopon/go-toposort
+	           github.com/philopon/go-toposort \
+			   gopkg.in/godbus/dbus.v5
 
 
 REST_BIN = $(BUILD_DIR)/rest_server/main
@@ -127,6 +128,17 @@ install:
 	cp -rf $(TOPDIR)/build/cli $(DESTDIR)/usr/sbin/
 	cp -rf $(TOPDIR)/build/swagger_client_py/ $(DESTDIR)/usr/sbin/lib/
 	cp -rf $(TOPDIR)/src/cvl/conf/cvl_cfg.json $(DESTDIR)/usr/sbin/cvl_cfg.json
+
+	# Scripts for host service
+	$(INSTALL) -d $(DESTDIR)/usr/lib/sonic_host_service/host_modules
+	$(INSTALL) -D $(TOPDIR)/scripts/sonic_host_server.py $(DESTDIR)/usr/lib/sonic_host_service
+	$(INSTALL) -D $(TOPDIR)/scripts/host_modules/*.py $(DESTDIR)/usr/lib/sonic_host_service/host_modules
+	$(INSTALL) -d $(DESTDIR)/etc/dbus-1/system.d
+	$(INSTALL) -D $(TOPDIR)/scripts/org.sonic.hostservice.conf $(DESTDIR)/etc/dbus-1/system.d
+	$(INSTALL) -d $(DESTDIR)/lib/systemd/system
+	$(INSTALL) -D $(TOPDIR)/scripts/sonic-hostservice.service $(DESTDIR)/lib/systemd/system
+
+
 
 ifeq ($(SONIC_COVERAGE_ON),y)
 	echo "" > $(DESTDIR)/usr/sbin/.test

--- a/debian/control
+++ b/debian/control
@@ -10,3 +10,9 @@ Priority: extra
 Architecture: amd64
 Depends: ${shlibs:Depends}, ${misc:Depends}  
 Description: SONiC Management Framework 
+
+Package: sonic-host-service
+Priority: extra
+Architecture: amd64
+Depends: python-dbus, python-gobject, ${shlibs:Depends}, ${misc:Depends}
+Description: SONiC Host Service

--- a/debian/sonic-host-service.install
+++ b/debian/sonic-host-service.install
@@ -1,0 +1,3 @@
+usr/lib/*
+etc/dbus-1/system.d/*
+lib/systemd/system/*

--- a/debian/sonic-mgmt-framework.install
+++ b/debian/sonic-mgmt-framework.install
@@ -1,0 +1,3 @@
+usr/sbin/*
+rest_ui/*
+usr/models/*

--- a/scripts/host_modules/host_service.py
+++ b/scripts/host_modules/host_service.py
@@ -1,0 +1,20 @@
+"""Base class for host modules"""
+
+import dbus.service
+import dbus
+
+BUS_NAME_BASE = 'org.SONiC.HostService'
+BUS_PATH = '/org/SONiC/HostService'
+
+def bus_name(mod_name):
+    """Return the bus name for the service"""
+    return BUS_NAME_BASE + '.' + mod_name
+
+method = dbus.service.method
+
+class HostModule(dbus.service.Object):
+    """Base class for all host modules"""
+    def __init__(self, mod_name):
+        self.bus = dbus.SystemBus()
+        self.bus_name = dbus.service.BusName(BUS_NAME_BASE, self.bus)
+        super(HostModule, self).__init__(self.bus_name, BUS_PATH)

--- a/scripts/host_modules/ztp.py
+++ b/scripts/host_modules/ztp.py
@@ -1,0 +1,43 @@
+"""ZTP command handler"""
+
+import host_service
+import subprocess
+
+MOD_NAME = 'ztp'
+
+class ZTP(host_service.HostModule):
+    """DBus endpoint that executes ZTP related commands
+    """
+    @staticmethod
+    def _run_command(commands):
+        """Run a ZTP command"""
+        cmd = ['/usr/bin/ztp']
+        if isinstance(commands, list):
+            cmd.extend(commands)
+        else
+            cmd.append(commands)
+
+        try:
+            rc = 0
+            output = subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as err:
+            rc = err.returncode
+            output = ""
+
+        return rc, output
+
+    @host_service.method(host_service.bus_name(MOD_NAME), in_signature='', out_signature='')
+    def enable(self):
+        _run_command("enable")
+
+    @host_service.method(host_service.bus_name(MOD_NAME), in_signature='', out_signature='')
+    def disable(self):
+        _run_command(["disable", "-y"])
+
+    @host_service.method(host_service.bus_name(MOD_NAME), in_signature='', out_signature='is')
+    def status(self):
+        return _run_command("status")
+
+def register():
+    """Return the class name"""
+    return ZTP

--- a/scripts/org.sonic.hostservice.conf
+++ b/scripts/org.sonic.hostservice.conf
@@ -1,0 +1,18 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+
+  <!-- Only root can own the bus -->
+
+  <policy user="root">
+    <allow own_prefix="org.SONiC.HostService"/>
+  </policy>
+
+  <!-- Allow user "root" to invoke methods on the bus -->
+  <policy user="root">
+    <allow send_destination="org.SONiC.HostService"/>
+    <allow receive_sender="org.SONiC.HostService"/>
+  </policy>
+
+</busconfig>

--- a/scripts/sonic-hostservice.service
+++ b/scripts/sonic-hostservice.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=SONiC Host Service
+
+[Service]
+Type=dbus
+BusName=org.SONiC.HostService
+
+ExecStart=/usr/bin/python2 -u /usr/lib/sonic_host_service/sonic_host_server.py
+
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/sonic_host_server.py
+++ b/scripts/sonic_host_server.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python2
+"""Host Service to handle docker-to-host communication"""
+
+import os
+import os.path
+import glob
+import importlib
+import sys
+
+import dbus
+import dbus.service
+import dbus.mainloop.glib
+import gobject
+
+BUS_NAME = 'org.SONiC.HostService'
+BUS_PATH = '/org/SONiC/HostService'
+
+def register_modules():
+    """Register all host modules"""
+    mod_path = os.path.join(os.path.dirname(__file__), 'host_modules')
+    sys.path.append(mod_path)
+    for mod_file in glob.glob(os.path.join(mod_path, '*.py')):
+        if os.path.isfile(mod_file) and not mod_file.endswith('__init__.py') \
+            and not mod_file.endswith('host_service.py'):
+            mod_name = os.path.basename(mod_file)[:-3]
+            module = importlib.import_module(mod_name)
+
+            register_cb = getattr(module, 'register', None)
+            if not register_cb:
+                raise Exception('Missing register function for ' + mod_name)
+
+            register_dbus(mod_name, register_cb())
+
+def register_dbus(mod_name, handler_class):
+    """Register DBus handlers for individual modules"""
+    handlers[mod_name] = handler_class(mod_name)
+
+# Create a main loop reactor
+gobject.threads_init()
+dbus.mainloop.glib.threads_init()
+dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
+loop = gobject.MainLoop()
+handlers = {}
+
+class SignalManager(object):
+    ''' This is used to manage signals received (e.g. SIGINT).
+        When stopping a process (systemctl stop [service]), systemd sends
+        a SIGTERM signal.
+    '''
+    shutdown = False
+    def __init__(self):
+        ''' Install signal handlers.
+
+            SIGTERM is invoked when systemd wants to stop the daemon.
+            For example, "systemctl stop mydaemon.service"
+            or,          "systemctl restart mydaemon.service"
+
+        '''
+        import signal
+        signal.signal(signal.SIGTERM, self.sigterm_hdlr)
+
+    def sigterm_hdlr(self, _signum, _frame):
+        self.shutdown = True
+        loop.quit()
+
+sigmgr = SignalManager()
+register_modules()
+
+# Only run if we actually have some handlers
+if handlers:
+    import systemd.daemon
+    systemd.daemon.notify("READY=1")
+
+    while not sigmgr.shutdown:
+        loop.run()
+        if sigmgr.shutdown:
+            break
+
+    systemd.daemon.notify("STOPPING=1")
+else:
+    print "No handlers to register, quitting..."

--- a/src/translib/transformer/host_comm.go
+++ b/src/translib/transformer/host_comm.go
@@ -1,0 +1,122 @@
+package transformer
+
+import (
+	// Go 1.11 doesn't let us download using the canonical import path
+	// "github.com/godbus/dbus/v5"
+	// This works around that problem by using gopkg.in instead
+	"gopkg.in/godbus/dbus.v5"
+)
+
+// hostResult contains the body of the response and the error if any, when the 
+// endpoint finishes servicing the D-Bus request.
+type hostResult struct {
+	Body	[]interface{}
+	Err		error
+}
+
+// hostQuery calls the corresponding D-Bus endpoint on the host and returns
+// any error and response body
+func hostQuery(endpoint string, args ...interface{}) (result hostResult) {
+	result_ch, err := hostQueryAsync(endpoint, args...)
+
+	if err != nil {
+		result.Err = err
+		return
+	}
+
+	result = <-result_ch
+	return
+}
+
+// hostQueryAsync calls the corresponding D-Bus endpoint on the host and returns
+// a channel for the result, and any error
+func hostQueryAsync(endpoint string, args ...interface{}) (chan hostResult, error) {
+	var result_ch = make(chan hostResult, 1)
+	conn, err := dbus.SystemBus()
+	if err != nil {
+		return result_ch, err
+	}
+
+	const bus_name = "org.SONiC.HostService"
+	const bus_path = "/org/SONiC/HostService"
+
+	obj := conn.Object(bus_name, bus_path)
+	dest := bus_name + "." + endpoint
+	dbus_ch := make(chan *dbus.Call, 1)
+
+	go func() {
+		var result hostResult
+
+		// Wait for a read on the channel
+		call := <-dbus_ch
+
+		if call.Err != nil {
+			result.Err = call.Err
+		} else {
+			result.Body = call.Body
+		}
+
+		// Write the result to the channel
+		result_ch <- result
+	}()
+
+	call := obj.Go(dest, 0, dbus_ch, args...)
+
+	if call.Err != nil {
+		return result_ch, call.Err
+	}
+
+	return result_ch, nil
+}
+
+// Example
+/*
+ztpAction calls the ZTP endpoint on the host and returns the status
+func ztpAction(action string) (string, error) {
+	var output string
+	// result.Body is of type []interface{}, since any data may be returned by
+	// the host server. The application is responsible for performing
+	// type assertions to get the correct data.
+	result := hostQuery("ztp." + action)
+
+	if result.Err != nil {
+		return output, result.Err
+	}
+
+	if action == "status" {
+		// ztp.status returns an exit code and the stdout of the command
+		// We only care about the stdout (which is at [1] in the slice)
+		output, _ = result.Body[1].(string)
+	}
+
+	return output, nil
+}
+
+// The following uses the hostQueryAsync option
+func ztpAction(action string) (string, error) {
+	var output string
+	// body is of type []interface{}, since any data may be returned by
+	// the host server. The application is responsible for performing
+	// type assertions to get the correct data.
+	ch, err := hostQueryAsync("ztp." + action)
+
+	if err != nil {
+		return output, err
+	}
+
+	// Wait for the call to finish
+	result := <-ch
+	if result.Err != nil {
+		return output, result.Err
+	}
+
+	if action == "status" {
+		// ztp.status returns an exit code and the stdout of the command
+		// We only care about the stdout (which is at [1] in the slice)
+		output, _ = result.Body[1].(string)
+	}
+
+	return output, nil
+}
+
+*/


### PR DESCRIPTION
This change adds infrastructure to create a host-side server that will
respond to specific requests over D-Bus. The intention is to let clients
that run within a container to query the host for the registered
requests. This also includes infrastructure in Translib to request the
host to perform some service.

This is primarily used for implementing actions that must be done in the
host system, such as image management, show techsupport, ZTP, etc.