### PR TITLE
Ability to start/stop profiling

### DIFF
--- a/src/rest/main/main.go
+++ b/src/rest/main/main.go
@@ -59,6 +59,8 @@ func init() {
 	flag.CommandLine.Parse([]string{})
 }
 
+var profRunning bool = true
+
 // Start REST server
 func main() {
 
@@ -75,8 +77,17 @@ func main() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGUSR1)
 	go func() {
+	  for {
 		<-sigs
-		prof.Stop()
+		if (profRunning) {
+			prof.Stop()
+			profRunning = false
+		} else {
+			prof = profile.Start()
+			defer prof.Stop()
+			profRunning = true
+		}
+	  }
 	}()
 
 	swagger.Load()


### PR DESCRIPTION
Rest-server will be started with cpu profiling enabled.

Sending SIGUSR1 will stop profiling. Sending another will restart profiling.