### PR TITLE
Fix DBus registration for host modules

### DIFF
--- a/scripts/host_modules/host_service.py
+++ b/scripts/host_modules/host_service.py
@@ -10,11 +10,25 @@ def bus_name(mod_name):
     """Return the bus name for the service"""
     return BUS_NAME_BASE + '.' + mod_name
 
+def bus_path(mod_name):
+    """Return the bus path for the service"""
+    return BUS_PATH + '/' + mod_name
+
 method = dbus.service.method
+
+class HostService(dbus.service.Object):
+    """Service class for top level DBus endpoint"""
+    def __init__(self, mod_name):
+        self.bus = dbus.SystemBus()
+        self.bus_name = dbus.service.BusName(BUS_NAME_BASE, self.bus)
+        super(HostService, self).__init__(self.bus_name, BUS_PATH)
 
 class HostModule(dbus.service.Object):
     """Base class for all host modules"""
     def __init__(self, mod_name):
         self.bus = dbus.SystemBus()
-        self.bus_name = dbus.service.BusName(BUS_NAME_BASE, self.bus)
-        super(HostModule, self).__init__(self.bus_name, BUS_PATH)
+        self.bus_name = dbus.service.BusName(bus_name(mod_name), self.bus)
+        super(HostModule, self).__init__(self.bus_name, bus_path(mod_name))
+
+def register():
+    return HostService

--- a/scripts/host_modules/host_service.py
+++ b/scripts/host_modules/host_service.py
@@ -31,4 +31,4 @@ class HostModule(dbus.service.Object):
         super(HostModule, self).__init__(self.bus_name, bus_path(mod_name))
 
 def register():
-    return HostService
+    return HostService, "host_service"

--- a/scripts/host_modules/ztp.py
+++ b/scripts/host_modules/ztp.py
@@ -11,7 +11,7 @@ class ZTP(host_service.HostModule):
     @staticmethod
     def _run_command(commands):
         """Run a ZTP command"""
-        cmd = ['/usr/bin/ztp']
+        cmd = ['echo', '/usr/bin/ztp']
         if isinstance(commands, list):
             cmd.extend(commands)
         else:
@@ -40,4 +40,4 @@ class ZTP(host_service.HostModule):
 
 def register():
     """Return the class name"""
-    return ZTP
+    return ZTP, MOD_NAME

--- a/scripts/sonic_host_server.py
+++ b/scripts/sonic_host_server.py
@@ -20,8 +20,7 @@ def register_modules():
     mod_path = os.path.join(os.path.dirname(__file__), 'host_modules')
     sys.path.append(mod_path)
     for mod_file in glob.glob(os.path.join(mod_path, '*.py')):
-        if os.path.isfile(mod_file) and not mod_file.endswith('__init__.py') \
-            and not mod_file.endswith('host_service.py'):
+        if os.path.isfile(mod_file) and not mod_file.endswith('__init__.py'):
             mod_name = os.path.basename(mod_file)[:-3]
             module = importlib.import_module(mod_name)
 

--- a/scripts/sonic_host_server.py
+++ b/scripts/sonic_host_server.py
@@ -28,10 +28,11 @@ def register_modules():
             if not register_cb:
                 raise Exception('Missing register function for ' + mod_name)
 
-            register_dbus(mod_name, register_cb())
+            register_dbus(register_cb)
 
-def register_dbus(mod_name, handler_class):
+def register_dbus(register_cb):
     """Register DBus handlers for individual modules"""
+    handler_class, mod_name = register_cb()
     handlers[mod_name] = handler_class(mod_name)
 
 # Create a main loop reactor

--- a/src/translib/transformer/host_comm.go
+++ b/src/translib/transformer/host_comm.go
@@ -1,6 +1,8 @@
 package transformer
 
 import (
+	"strings"
+
 	// Go 1.11 doesn't let us download using the canonical import path
 	// "github.com/godbus/dbus/v5"
 	// This works around that problem by using gopkg.in instead
@@ -37,11 +39,13 @@ func hostQueryAsync(endpoint string, args ...interface{}) (chan hostResult, erro
 		return result_ch, err
 	}
 
-	const bus_name = "org.SONiC.HostService"
-	const bus_path = "/org/SONiC/HostService"
+	service := strings.SplitN(endpoint, ".", 2)
+	const bus_name_base = "org.SONiC.HostService."
+	bus_name := bus_name_base + service[0]
+	bus_path := dbus.ObjectPath("/org/SONiC/HostService/" + service[0])
 
 	obj := conn.Object(bus_name, bus_path)
-	dest := bus_name + "." + endpoint
+	dest := bus_name_base + endpoint
 	dbus_ch := make(chan *dbus.Call, 1)
 
 	go func() {


### PR DESCRIPTION
Prior to this change, a second host module Python file would cause the
host service to fail to start, since it would be unable to register
against the DBus endpoint. The fix is to add an additional path, e.g.
`/org/SONiC/HostService/ztp`, during the registration step. This change
also adds a fix in hostQuery function to send the request to the correct
endpoint.