### PR TITLE
VRF configuration CLI publsih

### DIFF
--- a/src/CLI/actioner/sonic-cli-vrf.py
+++ b/src/CLI/actioner/sonic-cli-vrf.py
@@ -66,7 +66,7 @@ def run(func, args):
             # Get Command Output
             api_response = response.content
             if api_response is None:
-                print("Failed")
+                print("%Error: Transaction Failure")
     else:
         print response.error_message()
 

--- a/src/CLI/actioner/sonic-cli-vrf.py
+++ b/src/CLI/actioner/sonic-cli-vrf.py
@@ -21,120 +21,59 @@ import sys
 import time
 import json
 import ast
-import openconfig_network_instance_client
-from  openconfig_network_instance_client.rest import ApiException
+from rpipe_utils import pipestr
+import cli_client as cc
 from scripts.render_cli import show_cli_output
 
-import urllib3
-urllib3.disable_warnings()
+IDENTIFIER='VRF'
+NAME1='vrf'
 
-plugins = dict()
-
-def register(func):
-    """Register sdk client method as a plug-in"""
-    plugins[func.__name__] = func
-    return func
-
-
-def call_method(name, args):
-    method = plugins[name]
-    return method(args)
-
-def generate_body(func, args):
+def invoke_api(func, args=[]):
+    api = cc.ApiClient()
+    keypath = []
     body = None
-    # Get the all vrfs.
-    if func.__name__ == 'get_list_openconfig_network_instance_network_instances_network_instance':
-       keypath = []
 
-    # Get a specific vrf. 
-    elif func.__name__ == 'get_openconfig_network_instance_network_instances_network_instance':
-       keypath = [ args[0] ]
-
-    # Configure management vrf. maybe just set mgmt here without args[0] 
-    elif func.__name__ == 'patch_openconfig_network_instance_network_instances_network_instance' :
-       keypath = [ args[0] args[1] args[2] ]
-       body = { "openconfig-network-instance:config": {
-                   "name": args[0],
-                   "type": args[1],
-                   "enabled": args[2]
-                   "description": ""
-                 }
-              }
-
-    # Delete management vrf.
-    elif func.__name__ == 'delete_openconfig_network_instance_network_instances_network_instance':
-       keypath = [ args[0] args[1] args[2] ]
-       body = { "openconfig-network-instance:config": {
-                   "name": args[0],
-                   "type": args[1],
-                   "enabled": args[2]
-                   "description": ""
-                 }
-              }
-    
+    if func == 'patch_openconfig_network_instance_network_instances_network_instance':
+        keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}', name=args[0])
+        body = { "openconfig-network-instance:network-instance": [ { "name": args[0],
+                                                                     "config" : { "name": args[0],
+                                                                                  "type": args[1],
+                                                                                  "enabled": True if args[2] == "True" else False } } ] }
+        return api.patch(keypath, body)
+    elif func == 'delete_openconfig_network_instance_network_instances_network_instance':
+        keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}', name=args[0])
+        body = { "openconfig-network-instance:network-instance": [ { "name": args[0],
+                                                                     "config" : { "name": args[0],
+                                                                                  "type": args[1],
+                                                                                  "enabled": True if args[2] == "True" else False } } ] }
+        return api.patch(keypath, body)
+    elif func == 'get_openconfig_network_instance_network_instances_network_instance':
+        if args[0] == 'mgmt':
+	    keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/config', name=args[0])
+        else:
+	    keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance/config')
+        return api.get(keypath)
     else:
         body = {}
 
-    if body is not None:
-        body = json.dumps(body,ensure_ascii=False, indent=4, separators=(',', ':'))
-        return keypath, ast.literal_eval(body)
-    else:
-        return keypath, body
-
+    return api.cli_not_implemented(func)
 
 def run(func, args):
+    response = invoke_api(func, args)
 
-    c = openconfig_network_instance_client.Configuration()
-    c.verify_ssl = False
-    aa = openconfig_network_instance_client.OpenconfigNetworkInstanceApi(api_client=openconfig_network_instance_client.ApiClient(configuration=c))
-
-    # create a body block
-    keypath, body = generate_body(func, args)
-
-    try:
-        if body is not None:
-           api_response = getattr(aa,func.__name__)(*keypath, body=body)
-        else :
-           api_response = getattr(aa,func.__name__)(*keypath)
-
-        if api_response is None:
-            print ("Success")
-        else:
-            response = api_response.to_dict()
-            if 'openconfig_network_instancenetwork_instance' in response.keys():
-                value = response['openconfig_network_instancenetwork_instance']
-                if value is None:
-                    print("Success")
-                else:
-                    print ("Failed")
-            else:
+    if response.ok():
+        if response.content is not None:
+            # Get Command Output
+            api_response = response.content
+            if api_response is None:
                 print("Failed")
-
-    except ApiException as e:
-        print("Exception when calling OpenconfigNetworkInstanceApi->%s : %s\n" %(func.__name__, e))
-        if e.body != "":
-            body = json.loads(e.body)
-            if "ietf-restconf:errors" in body:
-                 err = body["ietf-restconf:errors"]
-                 if "error" in err:
-                     errList = err["error"]
-
-                     errDict = {}
-                     for dict in errList:
-                         for k, v in dict.iteritems():
-                              errDict[k] = v
-
-                     if "error-message" in errDict:
-                         print "%Error: " + errDict["error-message"]
-                         return
-                     print "%Error: Transaction Failure"
-                     return
-            print "%Error: Transaction Failure"
+    else:
+        print response.error_message()
 
 if __name__ == '__main__':
 
     pipestr().write(sys.argv)
-    #pdb.set_trace()
-    func = eval(sys.argv[1], globals(), openconfig_network_instance_client.OpenconfigNetworkInstanceApi.__dict__)
+    func = sys.argv[1]
+
     run(func, sys.argv[2:])
-                                                                                          
+

--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -37,21 +37,69 @@ limitations under the License.
 
     <VIEW name="configure-view">
     <!-- vrf configuration commands -->
-    <COMMAND name="ip vrf" help="VRF instance configuration"/>
-      <COMMAND name="ip vrf management" help="management VRF configuration" mode="subcommand" ptype="SUBCOMMAND">
-        <ACTION> 
-          python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True"&#xA; 
-        </ACTION> 
-      </COMMAND>
+    <COMMAND name="ip vrf management" help="management VRF configuration" mode="subcommand" ptype="SUBCOMMAND">
+      <ACTION> 
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True"&#xA; 
+      </ACTION> 
+    </COMMAND>
     
+    <COMMAND
+      name="ip vrf"
+      help="VRF instance configuration"
+      mode="subcommand"
+      ptype="SUBCOMMAND"
+      >
+      <PARAM
+        name="vrf-name"
+        help="Name of VRF (Max size 32, prefixed by Vrf_)"
+        ptype="STRING_32"
+        >
+      </PARAM>
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance ${vrf-name} "L3VRF" "True"&#xA;
+      </ACTION>
+    </COMMAND>
+
     <!-- no vrf commands -->
-    <COMMAND name="no ip vrf" help="Delete VRF instance"/>
-      <COMMAND name="no ip vrf management" help="Delete management VRF" mode="subcommand" ptype="SUBCOMMAND">
-        <ACTION> 
-          python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"&#xA;  
-        </ACTION>
-      </COMMAND>
+    <COMMAND name="no ip vrf management" help="Delete management VRF" mode="subcommand" ptype="SUBCOMMAND">
+      <ACTION> 
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"&#xA;  
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no ip vrf"
+      help="Delete VRF instance"
+      mode="subcommand"
+      ptype="SUBCOMMAND"
+      >
+      <PARAM
+        name="vrf-name"
+        help="Name of VRF (Max size 32, prefixed by Vrf_)"
+        ptype="STRING_32"
+        >
+      </PARAM>
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance ${vrf-name} "L3VRF" "False"&#xA;
+      </ACTION>
+    </COMMAND>
 
     </VIEW>
+
+<!--=======================================================-->
+<!--                Config Interface PHY-MODE              -->
+<!--=======================================================-->
+
+<VIEW name="configure-if-view">
+    <MACRO name="BIND-INTF-TO-VRF" arg=""></MACRO>
+</VIEW>
+
+<VIEW name="configure-lag-view">
+    <MACRO name="BIND-INTF-TO-VRF" arg=""></MACRO>
+</VIEW>
+
+<VIEW name="configure-vlan-view">
+    <MACRO name="BIND-INTF-TO-VRF" arg=""></MACRO>
+</VIEW>
 
 </CLISH_MODULE>

--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -25,12 +25,12 @@ limitations under the License.
     <VIEW name="enable-view">
       <COMMAND name="show ip vrf" help="Show vrf information">
         <ACTION> 
-          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py get_list_openconfig_network_instance_network_instances_network_instance show_mgmt_vrf.j2
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py get_openconfig_network_instance_network_instances_network_instance show_vrf.j2
         </ACTION>
       </COMMAND>
       <COMMAND name="show ip vrf management" help="Show management vrf information">
         <ACTION> 
-          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py get_openconfig_network_instance_network_instances_network_instance "mgmt" show_mgmt_vrf.j2
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py get_openconfig_network_instance_network_instances_network_instance "mgmt" show_vrf.j2
         </ACTION>
       </COMMAND>
     </VIEW>
@@ -40,7 +40,7 @@ limitations under the License.
     <COMMAND name="ip vrf" help="vrf instance configuration"/>
       <COMMAND name="ip vrf management" help="management vrf configuration" mode="subcommand" ptype="SUBCOMMAND">
         <ACTION> 
-          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" true&#xA; 
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True"&#xA; 
         </ACTION> 
       </COMMAND>
     
@@ -48,7 +48,7 @@ limitations under the License.
     <COMMAND name="no ip vrf" help="Delete vrf instance"/>
       <COMMAND name="no ip vrf management" help="Delete management vrf" mode="subcommand" ptype="SUBCOMMAND">
         <ACTION> 
-          python $SONIC_CLI_ROOT/openconfig_network_instance_api.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" true&#xA;  
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"&#xA;  
         </ACTION>
       </COMMAND>
 

--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -23,12 +23,12 @@ limitations under the License.
     http://www.dellemc.com/sonic/XMLSchema/clish.xsd"
     >
     <VIEW name="enable-view">
-      <COMMAND name="show ip vrf" help="Show vrf information">
+      <COMMAND name="show ip vrf" help="Show VRF information">
         <ACTION> 
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py get_openconfig_network_instance_network_instances_network_instance show_vrf.j2
         </ACTION>
       </COMMAND>
-      <COMMAND name="show ip vrf management" help="Show management vrf information">
+      <COMMAND name="show ip vrf management" help="Show management VRF information">
         <ACTION> 
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py get_openconfig_network_instance_network_instances_network_instance "mgmt" show_vrf.j2
         </ACTION>
@@ -37,16 +37,16 @@ limitations under the License.
 
     <VIEW name="configure-view">
     <!-- vrf configuration commands -->
-    <COMMAND name="ip vrf" help="vrf instance configuration"/>
-      <COMMAND name="ip vrf management" help="management vrf configuration" mode="subcommand" ptype="SUBCOMMAND">
+    <COMMAND name="ip vrf" help="VRF instance configuration"/>
+      <COMMAND name="ip vrf management" help="management VRF configuration" mode="subcommand" ptype="SUBCOMMAND">
         <ACTION> 
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True"&#xA; 
         </ACTION> 
       </COMMAND>
     
     <!-- no vrf commands -->
-    <COMMAND name="no ip vrf" help="Delete vrf instance"/>
-      <COMMAND name="no ip vrf management" help="Delete management vrf" mode="subcommand" ptype="SUBCOMMAND">
+    <COMMAND name="no ip vrf" help="Delete VRF instance"/>
+      <COMMAND name="no ip vrf management" help="Delete management VRF" mode="subcommand" ptype="SUBCOMMAND">
         <ACTION> 
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"&#xA;  
         </ACTION>

--- a/src/CLI/clitree/macro/vrf_macro.xml
+++ b/src/CLI/clitree/macro/vrf_macro.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright 2019 Dell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<ROOT>
+
+<MACRODEF name="BIND-INTF-TO-VRF">
+
+    <COMMAND name="ip vrf" help="Bind interface to specified VRF domain"/>
+    <COMMAND
+        name="ip vrf forwarding"
+        help="Configure forwarding table"
+        mode="subcommand"
+        ptype="SUBCOMMAND"
+        >
+        <PARAM
+          name="vrf-name"
+          help="Name of VRF (Max size 32, prefixed by Vrf_)"
+          ptype="STRING_32"
+          >
+        </PARAM>
+        <ACTION>
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance_interface ${vrf-name}&#xA;
+        </ACTION>
+    </COMMAND>
+
+    <COMMAND name="no ip vrf" help="Unbind interface from specified VRF domain"/>
+    <COMMAND
+        name="no ip vrf forwarding"
+        help="Configure forwarding table"
+        mode="subcommand"
+        ptype="SUBCOMMAND"
+        >
+        <ACTION>
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance_interface&#xA;
+        </ACTION>
+    </COMMAND>
+
+</MACRODEF>
+
+</ROOT>


### PR DESCRIPTION
This is to publish VRF configuration CLI commands:

sonic(config)# ip vrf
management management VRF configuration
String(Max: 32 characters) Name of VRF (Max size 32, prefixed by Vrf_)
sonic(config)# ip vrf Vrf_red
sonic(config)# no ip vrf Vrf_red

sonic(config)# interface Ethernet 4
sonic(conf-if-Ethernet4)# ip
access-group Specify access control for packets
address IP address
vrf Bind interface to specified VRF domain
sonic(conf-if-Ethernet4)# ip vrf forwarding
String(Max: 32 characters) Name of VRF (Max size 32, prefixed by Vrf_)
sonic(conf-if-Ethernet4)# ip vrf forwarding Vrf_red

sonic(config)# interface Ethernet 4
sonic(conf-if-Ethernet4)# no ip
access-group Specify access control for packets
address Interface Internet Protocol config commands
vrf Unbind interface from specified VRF domain
sonic(conf-if-Ethernet4)# no ip vrf
forwarding Configure forwarding table

sonic(conf-if-Ethernet4)# no ip vrf forwarding
sonic(config)# interface PortChannel 12
sonic(conf-if-po12)# ip vrf
forwarding Configure forwarding table
sonic(conf-if-po12)# ip vrf forwarding Vrf_blue

Here "ip vrf forwarding" is missing for Vlan and Looback interfaces due to their CLI XML's do not working yet.