### PR TITLE
Vrf config cli publish

### DIFF
--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -37,21 +37,69 @@ limitations under the License.
 
     <VIEW name="configure-view">
     <!-- vrf configuration commands -->
-    <COMMAND name="ip vrf" help="VRF instance configuration"/>
-      <COMMAND name="ip vrf management" help="management VRF configuration" mode="subcommand" ptype="SUBCOMMAND">
-        <ACTION> 
-          python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True"&#xA; 
-        </ACTION> 
-      </COMMAND>
+    <COMMAND name="ip vrf management" help="management VRF configuration" mode="subcommand" ptype="SUBCOMMAND">
+      <ACTION> 
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True"&#xA; 
+      </ACTION> 
+    </COMMAND>
     
+    <COMMAND
+      name="ip vrf"
+      help="VRF instance configuration"
+      mode="subcommand"
+      ptype="SUBCOMMAND"
+      >
+      <PARAM
+        name="vrf-name"
+        help="Name of VRF (Max size 32, prefixed by Vrf_)"
+        ptype="STRING_32"
+        >
+      </PARAM>
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance ${vrf-name} "L3VRF" "True"&#xA;
+      </ACTION>
+    </COMMAND>
+
     <!-- no vrf commands -->
-    <COMMAND name="no ip vrf" help="Delete VRF instance"/>
-      <COMMAND name="no ip vrf management" help="Delete management VRF" mode="subcommand" ptype="SUBCOMMAND">
-        <ACTION> 
-          python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"&#xA;  
-        </ACTION>
-      </COMMAND>
+    <COMMAND name="no ip vrf management" help="Delete management VRF" mode="subcommand" ptype="SUBCOMMAND">
+      <ACTION> 
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"&#xA;  
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no ip vrf"
+      help="Delete VRF instance"
+      mode="subcommand"
+      ptype="SUBCOMMAND"
+      >
+      <PARAM
+        name="vrf-name"
+        help="Name of VRF (Max size 32, prefixed by Vrf_)"
+        ptype="STRING_32"
+        >
+      </PARAM>
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance ${vrf-name} "L3VRF" "False"&#xA;
+      </ACTION>
+    </COMMAND>
 
     </VIEW>
+
+<!--=======================================================-->
+<!--                Config Interface PHY-MODE              -->
+<!--=======================================================-->
+
+<VIEW name="configure-if-view">
+    <MACRO name="BIND-INTF-TO-VRF" arg=""></MACRO>
+</VIEW>
+
+<VIEW name="configure-lag-view">
+    <MACRO name="BIND-INTF-TO-VRF" arg=""></MACRO>
+</VIEW>
+
+<VIEW name="configure-vlan-view">
+    <MACRO name="BIND-INTF-TO-VRF" arg=""></MACRO>
+</VIEW>
 
 </CLISH_MODULE>

--- a/src/CLI/clitree/macro/vrf_macro.xml
+++ b/src/CLI/clitree/macro/vrf_macro.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright 2019 Dell, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<ROOT>
+
+<MACRODEF name="BIND-INTF-TO-VRF">
+
+    <COMMAND name="ip vrf" help="Bind interface to specified VRF domain"/>
+    <COMMAND
+        name="ip vrf forwarding"
+        help="Configure forwarding table"
+        mode="subcommand"
+        ptype="SUBCOMMAND"
+        >
+        <PARAM
+          name="vrf-name"
+          help="Name of VRF (Max size 32, prefixed by Vrf_)"
+          ptype="STRING_32"
+          >
+        </PARAM>
+        <ACTION>
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance_interface ${vrf-name}&#xA;
+        </ACTION>
+    </COMMAND>
+
+    <COMMAND name="no ip vrf" help="Unbind interface from specified VRF domain"/>
+    <COMMAND
+        name="no ip vrf forwarding"
+        help="Configure forwarding table"
+        mode="subcommand"
+        ptype="SUBCOMMAND"
+        >
+        <ACTION>
+          python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance_interface&#xA;
+        </ACTION>
+    </COMMAND>
+
+</MACRODEF>
+
+</ROOT>


### PR DESCRIPTION
This is to publish VRF configuration CLI commands:

sonic(config)# ip vrf
management management VRF configuration
String(Max: 32 characters) Name of VRF (Max size 32, prefixed by Vrf_)
sonic(config)# ip vrf Vrf_red
sonic(config)# no ip vrf Vrf_red

sonic(config)# interface Ethernet 4
sonic(conf-if-Ethernet4)# ip
access-group Specify access control for packets
address IP address
vrf Bind interface to specified VRF domain
sonic(conf-if-Ethernet4)# ip vrf forwarding
String(Max: 32 characters) Name of VRF (Max size 32, prefixed by Vrf_)
sonic(conf-if-Ethernet4)# ip vrf forwarding Vrf_red

sonic(config)# interface PortChannel 12
sonic(conf-if-po12)# ip vrf
  forwarding  Configure forwarding table
sonic(conf-if-po12)# ip vrf forwarding Vrf_blue
sonic(conf-if-po12)# exit

sonic(config)# ip vrf
  management                  management VRF configuration
  String(Max: 32 characters)  Name of VRF (Max size 32, prefixed by Vrf_)
sonic(config)# interface Ethernet 4
sonic(conf-if-Ethernet4)# no ip
access-group Specify access control for packets
address Interface Internet Protocol config commands
vrf Unbind interface from specified VRF domain
sonic(conf-if-Ethernet4)# no ip vrf
forwarding Configure forwarding table

sonic(conf-if-Ethernet4)# no ip vrf forwarding
sonic(config)# interface PortChannel 12
sonic(conf-if-po12)# ip vrf
forwarding Configure forwarding table
sonic(conf-if-po12)# ip vrf forwarding Vrf_blue


Here "ip vrf forwarding" is missing for Vlan and Looback interfaces due to their CLI XML's
do not working yet.
