### PR TITLE
clearing typo in image_mgmt.py in host_modulers

### DIFF
--- a/scripts/host_modules/image_mgmt.py
+++ b/scripts/host_modules/image_mgmt.py
@@ -30,7 +30,7 @@ class IMAGE_MGMT(host_service.HostModule):
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
     def action(self, options):
-        return IMAAGE_MGMT._run_command(options)
+        return IMAGE_MGMT._run_command(options)
         
 def register():
     """Return class name"""


### PR DESCRIPTION
Fix for a typo image_mgmt.py in scripts/host_modules directory 