### PR TITLE
Add default network instance type behavior in table name transformer, and check for configDB VRF entry for UPDATE case

### DIFF
--- a/src/translib/transformer/xfmr_vrf.go
+++ b/src/translib/transformer/xfmr_vrf.go
@@ -171,36 +171,6 @@ func isMgmtVrf(inParams XfmrParams) (bool, error) {
         }
 }
 
-/* NewPathInfoFirstKey parses given path string into a PathInfo structure containing the 1st key */
-func NewPathInfoFirstKey(path string) *PathInfo {
-        var info PathInfo
-        info.Path = path
-        info.Vars = make(map[string]string)
-
-        var template strings.Builder
-        r := strings.NewReader(path)
-
-        for r.Len() > 0 {
-                c, _ := r.ReadByte()
-                if c != '[' {
-                        template.WriteByte(c)
-                        continue
-                }
-
-                name := readUntil(r, '=')
-                value := readUntil(r, ']')
-                if len(name) != 0 {
-                        fmt.Fprintf(&template, "{%s}", name)
-                        info.Vars[name] = value
-                        break;
-                }
-        }
-
-        info.Template = template.String()
-
-        return &info
-}
-
 func init() {
         XlateFuncBind("network_instance_table_name_xfmr", network_instance_table_name_xfmr)
         XlateFuncBind("YangToDb_network_instance_table_key_xfmr", YangToDb_network_instance_table_key_xfmr)
@@ -240,7 +210,7 @@ var network_instance_table_name_xfmr TableXfmrFunc = func (inParams XfmrParams) 
                 return tblList, errors.New("Network instance not set")
         }
 
-        pathInfo := NewPathInfoFirstKey(inParams.uri)
+        pathInfo := NewPathInfo(inParams.uri)
 
         /* get the name at the top network-instance table level, this is the key */
         keyName := pathInfo.Var("name")

--- a/src/translib/transformer/xfmr_vrf.go
+++ b/src/translib/transformer/xfmr_vrf.go
@@ -6,7 +6,6 @@ import (
         "github.com/openconfig/ygot/ygot"
         "strings"
         "translib/ocbinds"
-        "fmt"
 )
 
 type NwInstMapKey struct {

--- a/src/translib/transformer/xfmr_vrf.go
+++ b/src/translib/transformer/xfmr_vrf.go
@@ -291,11 +291,6 @@ var network_instance_table_name_xfmr TableXfmrFunc = func (inParams XfmrParams) 
 
                 tblList = append(tblList, tblName)
         } else {
-                if (keyName == "default") {
-                        log.Info("network_instance_table_name_xfmr: UPDATE case for default network instance")
-                        return tblList, err
-                }
-
                 tblList = append(tblList, NwInstTblNameMapWithName[intNwInstName])
         }
 

--- a/src/translib/transformer/xfmr_vrf.go
+++ b/src/translib/transformer/xfmr_vrf.go
@@ -6,6 +6,7 @@ import (
         "github.com/openconfig/ygot/ygot"
         "strings"
         "translib/ocbinds"
+        "translib/db"
 )
 
 type NwInstMapKey struct {
@@ -21,12 +22,12 @@ const (
         MGMT_VRF_NAME          = "mgmt-vrf-name"
 )
 
+const (
+        DEFAULT_NETWORK_INSTANCE_CONFIG_TYPE        = "L3VRF"
+)
+
 var nwInstTypeMap = map[ocbinds.E_OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE] string {
-        ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_UNSET: "",
         ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_DEFAULT_INSTANCE: "DEFAULT_INSTANCE",
-        ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L2L3: "L2L3",
-        ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L2P2P: "L2P2P",
-        ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L2VSI: "L2VSI",
         ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_L3VRF: "L3VRF",
 }
 
@@ -35,6 +36,7 @@ var NwInstTblNameMapWithNameAndType = map[NwInstMapKey]string {
         {NwInstName: "mgmt", NwInstType: "L3VRF"}: "MGMT_VRF_CONFIG",
         {NwInstName: "Vrf",  NwInstType: "L3VRF"}: "VRF",
         {NwInstName: "default", NwInstType: "L3VRF"}: "",
+        {NwInstName: "default", NwInstType: "DEFAULT_INSTANCE"}: "",
 }
 
 /* Top level network instance table name based on key name */
@@ -127,12 +129,18 @@ func mgmtVrfEnabledInDb (inParams XfmrParams) (string) {
 func getNwInstType (nwInstObj *ocbinds.OpenconfigNetworkInstance_NetworkInstances, keyName string) (string, error) {
         var err error
 
-        nwInstType := nwInstTypeMap[nwInstObj.NetworkInstance[keyName].Config.Type]
-        if nwInstType == "" {
-                return nwInstType, errors.New("network instance type not set")
+        /* If config not set or config.type not set, return L3VRF */
+        if ((nwInstObj.NetworkInstance[keyName].Config == nil) ||
+            (nwInstObj.NetworkInstance[keyName].Config.Type == ocbinds.OpenconfigNetworkInstanceTypes_NETWORK_INSTANCE_TYPE_UNSET)) {
+                return DEFAULT_NETWORK_INSTANCE_CONFIG_TYPE, err
+        } else {
+                instType, ok :=nwInstTypeMap[nwInstObj.NetworkInstance[keyName].Config.Type]
+                if ok {
+                        return instType, err
+                } else {
+                        return instType, errors.New("Unknow network instance type")
+                }
         }
-
-        return nwInstType, err
 }
 
 /* Check if this is mgmt vrf configuration. Note this is used for create, update only */
@@ -163,6 +171,11 @@ func isMgmtVrf(inParams XfmrParams) (bool, error) {
         }
 }
 
+/* build db key from a given key string */
+func  buildKey(keyParts ...string) db.Key {
+        return db.Key{Comp: keyParts}
+}
+
 func init() {
         XlateFuncBind("network_instance_table_name_xfmr", network_instance_table_name_xfmr)
         XlateFuncBind("YangToDb_network_instance_table_key_xfmr", YangToDb_network_instance_table_key_xfmr)
@@ -190,6 +203,8 @@ func getNwInstRoot(s *ygot.GoStruct) *ocbinds.OpenconfigNetworkInstance_NetworkI
         return deviceObj.NetworkInstances
 }
 
+
+
 /* Table name in config DB correspoinding to the top level network instance name */
 var network_instance_table_name_xfmr TableXfmrFunc = func (inParams XfmrParams)  ([]string, error) {
         var tblList []string
@@ -206,9 +221,6 @@ var network_instance_table_name_xfmr TableXfmrFunc = func (inParams XfmrParams) 
 
         /* get the name at the top network-instance table level, this is the key */
         keyName := pathInfo.Var("name")
-        if keyName == "default" {
-           return tblList, err
-        }
 
         if keyName == "" {
                 /* for GET with no keyName, return table name for mgmt VRF and data VRF */
@@ -231,17 +243,12 @@ var network_instance_table_name_xfmr TableXfmrFunc = func (inParams XfmrParams) 
                 return tblList, errors.New("Invalide network instance name")
         }
 
-        /*
-         * for GET or DELETE, use the key "name" only to get the DB table name
-         * for CREATE, UPDATE or REPLACE, use the key "name" and type to get the DB table name
-         */
+        /* For CREATE or PATCH at top level (Network_instances), check the config type if user provides one */
         if ((inParams.oper == CREATE) ||
-            (inParams.oper == UPDATE) ||
-            (inParams.oper == REPLACE))  {
-                /* get the type for the network instance config */
+            ((inParams.oper == UPDATE) && (inParams.requestUri == "/openconfig-network-instance:network-instances"))) {
                 oc_nwInstType, ierr := getNwInstType(nwInstObj, keyName)
                 if (ierr != nil ) {
-                        log.Info("network_instance_table_name_xfmr, network instance type not correct")
+                        log.Info("network_instance_table_name_xfmr, network instance type not correct ", oc_nwInstType)
                         return tblList, errors.New("network instance type incorrect")
                 }
 
@@ -249,10 +256,56 @@ var network_instance_table_name_xfmr TableXfmrFunc = func (inParams XfmrParams) 
                 log.Info("network_instance_table_name_xfmr, type ", oc_nwInstType)
 
                 tblList = append(tblList, NwInstTblNameMapWithNameAndType[NwInstMapKey{intNwInstName, oc_nwInstType}])
-        } else {
+
+        } else if (inParams.oper == UPDATE) {
+                if (keyName == "default") {
+                        log.Info("network_instance_table_name_xfmr: UPDATE case for default network instance")
+                        return tblList, err
+                }
+
+                /* for a real UPDATE, check if the respective table entry is in the config DB, if not reject */
+                //tblName := NwInstTblNameMapWithName[intNwInstName]
+                /* build the table entry and check if the entry is in the db */
+                d, err := db.NewDB(getDBOptions(db.ConfigDB))
+                if err != nil {
+                        log.Info("network_instance_table_name_xfmr: no DB found")
+                        return tblList, errors.New("no config DB found for network instance")
+                }
+
+                var nwInstTable     *db.TableSpec
+
+                if (intNwInstName == "mgmt") {
+                        nwInstTable =  &db.TableSpec{Name: "MGMT_VRF_CONFIG"}
+                        dbInfo, _ := d.GetEntry(nwInstTable, buildKey("vrf_global"))
+                        if (!dbInfo.IsPopulated()) {
+                                log.Info("network_instance_table_name_xfmr: UPDATE case, DB entry not created for mgmt")
+                                return tblList, errors.New("DB entry not created yet")
+                        }
+               } else if (intNwInstName == "Vrf") {
+                       nwInstTable = &db.TableSpec{Name: "VRF"}
+                       dbInfo, _ := d.GetEntry(nwInstTable, buildKey(keyName))
+                       if (!dbInfo.IsPopulated()) {
+                                log.Info("network_instance_table_name_xfmr: UPDATE case, DB entry not created for ", keyName)
+                                return tblList, errors.New("DB entry not created yet")
+                        }
+               } else {
+                       log.Info("network_instance_table_name_xfmr: UPDATE case, unknown name ", keyName)
+                       return tblList, errors.New("Unknown network instance name")
+               }
+
+               log.Info("network_instance_table_name_xfmr, name ", keyName)
+               tblList = append(tblList, NwInstTblNameMapWithName[intNwInstName]) 
+        } else  {
+                if (keyName == "default") {
+                        log.Info("network_instance_table_name_xfmr: GET or DELETE case for default network instance")
+                        return tblList, err
+                }
+
+                /* for GET or DELETE */
                 tblList = append(tblList, NwInstTblNameMapWithName[intNwInstName])
         }
 
+        log.Info("network_instance_table_name_xfmr, OP ", inParams.oper)
         log.Info("network_instance_table_name_xfmr,  DB table name ", tblList)
 
         return tblList, err


### PR DESCRIPTION
1. In the network instance table transformer, address vrf config type default value in transformer function . 
    if the rest command for network instance comes without config or config/type, assign the default type "L3VRF" for internal use.

2. If "DEFAULT_INSTANCE" type is used other than "default", throw an error

3. use a local function NewPathInfoFirstKey(inParams.uri) to return the first key (name) from the uri passed in. This is to address the case where the inParams.uri passed to top level table name transformer is not the top level network instance, but rather the requestUri for the child (which also contains key (name))