### PR TITLE
Sonic "show tech-support" Add Translib input validation, enhance error…

### DIFF
--- a/models/yang/sonic/sonic-show-techsupport.yang
+++ b/models/yang/sonic/sonic-show-techsupport.yang
@@ -26,8 +26,8 @@ module sonic-show-techsupport {
             leaf date {
                 type yang:date-and-time;
                 description
-                    "Date and time specification (in Linux 'date' format) of desired
-                    start point for collected log information";
+                    "Date and time specification of the desired start
+                    point for collected log and core information";
             }
         }
         output {

--- a/scripts/host_modules/showtech.py
+++ b/scripts/host_modules/showtech.py
@@ -39,7 +39,7 @@ class Showtech(host_service.HostModule):
             else:
                 output = errmsg
 
-            print("Host side: Failed: " + str(rc))
+            print("%Error: Host side: Failed: " + str(rc))
             return rc, output
 
         output_string = output.decode("utf-8")

--- a/scripts/host_modules/showtech.py
+++ b/scripts/host_modules/showtech.py
@@ -11,6 +11,15 @@ class Showtech(host_service.HostModule):
     """
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
     def info(self, date):
+
+        ERROR_TAR_FAILED = 5
+        ERROR_PROCFS_SAVE_FAILED = 6
+        ERROR_INVALID_ARGUMENT = 10
+
+        err_dict = {ERROR_INVALID_ARGUMENT: 'Invalid input: Incorrect DateTime format',
+                    ERROR_TAR_FAILED: 'Failure saving information into compressed output file',
+                    ERROR_PROCFS_SAVE_FAILED: 'Saving of process information failed'}
+
         print("Host side: Running show techsupport")
         cmd = ['/usr/bin/generate_dump']
         if date:
@@ -20,11 +29,19 @@ class Showtech(host_service.HostModule):
         try:
             rc = 0
             output = subprocess.check_output(cmd)
+
         except subprocess.CalledProcessError as err:
             rc = err.returncode
-            output = ""
-            print("Host side: Failed", rc)
+            errmsg = err_dict.get(rc)
+
+            if errmsg is None:
+                output = 'Error: Failure code {:-5}'.format(rc)
+            else:
+                output = errmsg
+
+            print("Host side: Failed: " + str(rc))
             return rc, output
+
         output_string = output.decode("utf-8")
         output_file_match = re.search('\/var\/.*dump.*\.gz', output_string)
         if output_file_match is not None:

--- a/src/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/src/CLI/actioner/sonic-cli-show-techsupport.py
@@ -32,19 +32,19 @@ def run(func, args):
         api_response = invoke(func, args)
 
     except:
-        print("An exception occurred while attempting to gather the "
+        print("%Error: An exception occurred while attempting to gather the "
               "requested information via a remote procedure call. ")
 
     response = api_response.content
     if ((response is None) or
        (response['sonic-show-techsupport:output'] is None)):
-        print("Command Failure: Unknown failure type")
+        print("%Error: Command Failure: Unknown failure type")
         return
 
     output_msg_object = response['sonic-show-techsupport:output']
     if ((output_msg_object['output-filename'] is None) or
        (len(output_msg_object['output-filename']) is 0)):
-        print("Command Failure: Unknown failure type")
+        print("%Error: Command Failure: Unknown failure type")
         return
 
     if not api_response.ok():

--- a/src/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/src/CLI/actioner/sonic-cli-show-techsupport.py
@@ -2,6 +2,7 @@
 
 import sys
 import cli_client as cc
+import re
 
 def invoke(func, args):
     body = None
@@ -22,42 +23,47 @@ def invoke(func, args):
 
 def run(func, args):
 
+    if func != 'rpc_sonic_show_techsupport_sonic_show_techsupport_info':
+        print("ERROR: Python: Show Techsupport parsing Failed: Invalid "
+              "function")
+        return
+
     try:
         api_response = invoke(func, args)
 
-        if api_response.ok():
-            response = api_response.content
-
-            if response is None:
-                print ("ERROR: No output file generated")
-
-	    else:
-		if func == 'rpc_sonic_show_techsupport_sonic_show_techsupport_info':
-                    if not response['sonic-show-techsupport:output']:
-                        print("ERROR: no output file available")
-                        return
-                    elif response['sonic-show-techsupport:output'] is None:
-                        print("ERROR: No output file available")
-		        return
-                    output_file_object = response['sonic-show-techsupport:output']
-                    if output_file_object['output-filename'] is None:
-                        print("ERROR: No output file available")
-                        return
-                    output_filename = output_file_object['output-filename']
-                    if len(output_filename) is 0:
-                        print("Invalid input: Incorrect DateTime format")
-                    else:
-                        print("Output stored in:  " + output_filename)
-		else:
-                    print("ERROR: Python: Show Techsupport parsing Failed: Invalid function")
-        else:
-            #error response
-            print api_response.error_message()
-
     except:
-        print("An exception occurred while attempting to gather the requested "
-              "information via a remote procedure call. The failing RPC function "
-              " is: %s\n" %(func))
+        print("An exception occurred while attempting to gather the "
+              "requested information via a remote procedure call. ")
+
+    response = api_response.content
+    if ((response is None) or
+       (response['sonic-show-techsupport:output'] is None)):
+        print("Command Failure: Unknown failure type")
+        return
+
+    output_msg_object = response['sonic-show-techsupport:output']
+    if ((output_msg_object['output-filename'] is None) or
+       (len(output_msg_object['output-filename']) is 0)):
+        print("Command Failure: Unknown failure type")
+        return
+
+    if not api_response.ok():
+        # Print the message for a failing return code
+        print(output_msg_object['output-filename'])
+        return
+
+    # No error code flagged: Normal case handling
+    output_message = output_msg_object['output-filename']
+    output_file_match = re.search('\/var\/.*dump.*\.gz',
+                                  output_message)
+    if output_file_match is not None:
+        output_filename = output_file_match.group()
+        print("Output stored in:  " + output_filename)
+    else:
+        # Error message with non-error return code
+        print(output_message)
+
+
 
 if __name__ == '__main__':
     if len(sys.argv) == 3:

--- a/src/CLI/actioner/sonic-cli-show-techsupport.py
+++ b/src/CLI/actioner/sonic-cli-show-techsupport.py
@@ -24,7 +24,7 @@ def invoke(func, args):
 def run(func, args):
 
     if func != 'rpc_sonic_show_techsupport_sonic_show_techsupport_info':
-        print("ERROR: Python: Show Techsupport parsing Failed: Invalid "
+        print("%Error: Show Techsupport parsing Failed: Invalid "
               "function")
         return
 

--- a/src/CLI/clitree/cli-xml/show_techsupport.xml
+++ b/src/CLI/clitree/cli-xml/show_techsupport.xml
@@ -35,8 +35,16 @@ limitations under the License.
 
             <PARAM
                 name="date"
-                help="String specifying date/time in the same format as the 
-                      Linux &quot;date&quot; command"
+                help="date/time in the format:&#xA;&#xA;
+                    &quot;YYYY-MM-DDTHH:MM:SS[.ddd...]Z&quot; or&#xA;
+                    &quot;YYYY-MM-DDTHH:MM:SS[.ddd...]+hh:mm&quot; or&#xA;
+                    &quot;YYYY-MM-DDTHH:MM:SS[.ddd...]-hh:mm&quot; Where:&#xA;&#xA;
+                    YYYY = year, MM = month, DD = day,&#xA;
+                    T (required before time),&#xA;
+                    HH = hours, MM = minutes, SS = seconds,&#xA;
+                    (optional) .ddd... = decimal fraction of a second (e.g. &quot;.323&quot;)&#xA;
+                    Z indicates zero offset from local time&#xA;
+                    +/- hh:mm indicates hour:minute offset from local time"
                 ptype="STRING">
             </PARAM>
         </PARAM>

--- a/src/translib/transformer/xfmr_showtech.go
+++ b/src/translib/transformer/xfmr_showtech.go
@@ -23,6 +23,7 @@ import (
     "translib/tlerr"
     "translib/db"
     "github.com/golang/glog"
+    "regexp"
 )
 
 func init() {
@@ -31,23 +32,37 @@ func init() {
 
 var rpc_showtech_cb RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) ([]byte, error) {
     var err error
+    var matched bool
     var output string
     var operand struct {
         Input struct {
-        Date string `json:"date"`
+            Date string `json:"date"`
         } `json:"sonic-show-techsupport:input"`
     }
 
     err = json.Unmarshal(body, &operand)
-        if err != nil {
+    if err != nil {
         glog.Errorf("Failed to parse rpc input; err=%v", err)
         return nil,tlerr.InvalidArgs("Invalid rpc input")
+    }
+
+    if operand.Input.Date == "" {
+        matched = true
+    } else {
+        matched, err = regexp.MatchString((`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?` +
+                                           `(Z|[\+\-]\d{2}:\d{2})`), operand.Input.Date)
     }
 
     var showtech struct {
         Output struct {
         Result string `json:"output-filename"`
         } `json:"sonic-show-techsupport:output"`
+    }
+
+    if matched != true {
+        showtech.Output.Result = "Invalid input: Incorrect DateTime format"
+        result, _ := json.Marshal(&showtech)
+        return result, nil
     }
 
     host_output := hostQuery("showtech.info", operand.Input.Date)
@@ -60,7 +75,7 @@ var rpc_showtech_cb RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) ([]by
     output, _ = host_output.Body[1].(string)
     showtech.Output.Result = output
 
-    result, err := json.Marshal(&showtech)
+    result, _ := json.Marshal(&showtech)
 
     return result, nil
 }

--- a/src/translib/transformer/xfmr_showtech.go
+++ b/src/translib/transformer/xfmr_showtech.go
@@ -42,7 +42,7 @@ var rpc_showtech_cb RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) ([]by
 
     err = json.Unmarshal(body, &operand)
     if err != nil {
-        glog.Errorf("Failed to parse rpc input; err=%v", err)
+        glog.Errorf("%Error: Failed to parse rpc input; err=%v", err)
         return nil,tlerr.InvalidArgs("Invalid rpc input")
     }
 
@@ -67,7 +67,7 @@ var rpc_showtech_cb RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) ([]by
 
     host_output := hostQuery("showtech.info", operand.Input.Date)
     if host_output.Err != nil {
-        glog.Errorf("Showtech host Query failed: err=%v", host_output.Err)
+        glog.Errorf("%Error: Showtech host Query failed: err=%v", host_output.Err)
         glog.Flush()
         return nil, host_output.Err
     }


### PR DESCRIPTION
- Provide input parameter validity checking and error reporting within the
"show tech-support" Translib RPC callback function. This is needed because the
flow of control for RPC commands does not utilize the YGOT infrastructure and
associated input validation.

- Provide detailed syntax description in the CLI "help" menu for the "since <date>" option to explain the details for the required input. (This is based on the IETF/YANG date/time format requirements and options.)

- Provide enhanced error reporting for each of the types of errors defined in
the host script invoked by the "show tech-support" command to perform
the collection of technical support information.

Unit Test Enclosure (including a display of the revised CLI "help" menu):

[Unit Test with added Translib validation.docx](https://github.com/project-arlo/sonic-mgmt-framework/files/3913867/Unit.Test.with.added.Translib.validation.docx)
