### PR TITLE
do not send body with delete collector/deviceid restapi; add must statement for ipaddress/type validation

### DIFF
--- a/models/yang/sonic/sonic-tam.yang
+++ b/models/yang/sonic/sonic-tam.yang
@@ -54,7 +54,7 @@ module sonic-tam {
                 leaf ipaddress-type {
                     must "(contains(../ipaddress, ':') and current()='ipv6') or
                           (contains(../ipaddress, '.') and current()='ipv4')" {
-                        error-app-tag "Error: Wrong ipaddress for the specified ipaddress-type";
+                        error-message "%Error: Wrong ipaddress for the specified ipaddress-type";
                     }
 
                     type enumeration {

--- a/models/yang/sonic/sonic-tam.yang
+++ b/models/yang/sonic/sonic-tam.yang
@@ -55,7 +55,7 @@ module sonic-tam {
                     must "(contains(../ipaddress, ':') and current()='ipv6') or
                           (contains(../ipaddress, '.') and current()='ipv4')" {
                         error-message "%Error: Wrong ipaddress for the specified ipaddress-type";
-                        error-app-tag "%Error: Wrong ipaddress for the specified ipaddress-type";
+                        error-app-tag invalid-ipaddress;
                     }
 
                     type enumeration {

--- a/models/yang/sonic/sonic-tam.yang
+++ b/models/yang/sonic/sonic-tam.yang
@@ -55,6 +55,7 @@ module sonic-tam {
                     must "(contains(../ipaddress, ':') and current()='ipv6') or
                           (contains(../ipaddress, '.') and current()='ipv4')" {
                         error-message "%Error: Wrong ipaddress for the specified ipaddress-type";
+                        error-app-tag "%Error: Wrong ipaddress for the specified ipaddress-type";
                     }
 
                     type enumeration {

--- a/models/yang/sonic/sonic-tam.yang
+++ b/models/yang/sonic/sonic-tam.yang
@@ -52,6 +52,11 @@ module sonic-tam {
                 }
 
                 leaf ipaddress-type {
+                    must "(contains(../ipaddress, ':') and current()='ipv6') or
+                          (contains(../ipaddress, '.') and current()='ipv4')" {
+                        error-app-tag "Error: Wrong ipaddress for the specified ipaddress-type";
+                    }
+
                     type enumeration {
                         enum ipv4;
                         enum ipv6;

--- a/src/CLI/actioner/sonic-cli-tam.py
+++ b/src/CLI/actioner/sonic-cli-tam.py
@@ -46,7 +46,7 @@ def invoke_api(func, args):
        return api.patch(path, body)
     elif func == 'delete_sonic_tam_sonic_tam_tam_device_table_tam_device_table_list_deviceid':
        path = cc.Path('/restconf/data/sonic-tam:sonic-tam/TAM_DEVICE_TABLE/TAM_DEVICE_TABLE_LIST={name}/deviceid', name=args[0])
-       return api.delete(path, body)
+       return api.delete(path)
     elif func == 'patch_list_sonic_tam_sonic_tam_tam_collector_table_tam_collector_table_list':
        path = cc.Path('/restconf/data/sonic-tam:sonic-tam/TAM_COLLECTOR_TABLE/TAM_COLLECTOR_TABLE_LIST')
        body = {
@@ -59,7 +59,7 @@ def invoke_api(func, args):
        return api.patch(path, body)
     elif func == 'delete_sonic_tam_sonic_tam_tam_collector_table_tam_collector_table_list':
        path = cc.Path('/restconf/data/sonic-tam:sonic-tam/TAM_COLLECTOR_TABLE/TAM_COLLECTOR_TABLE_LIST={name}', name=args[0])
-       return api.delete(path, body)
+       return api.delete(path)
     else:
        body = {}
 

--- a/src/CLI/clitree/cli-xml/tam.xml
+++ b/src/CLI/clitree/cli-xml/tam.xml
@@ -92,7 +92,7 @@ limitations under the License.
              help="Collector name" 
              ptype="STRING"> 
       </PARAM>
-      <PARAM name="ip-type" 
+      <PARAM name="type" 
              help="Collector ip address type" 
              ptype="SUBCOMMAND" 
              mode="subcommand">

--- a/src/CLI/clitree/cli-xml/tam.xml
+++ b/src/CLI/clitree/cli-xml/tam.xml
@@ -101,7 +101,7 @@ limitations under the License.
                ptype="IP_TYPE"> 
         </PARAM>
       </PARAM>
-      <PARAM name="ip-addr" 
+      <PARAM name="ip" 
              help="Collector ip address" 
              ptype="SUBCOMMAND" 
              mode="subcommand">


### PR DESCRIPTION
The PR has three changes.
One was to remove body while calling delete() for no collector/deviceid commands.
```
sonic(config-tam)# do show tam collector
------------------------------------------------------------------------------------------------
NAME           IP TYPE        IP ADDRESS     PORT
------------------------------------------------------------------------------------------------
c1             ipv4           1.1.1.1        10
c99            ipv4           1.1.1.1        990
cnew           ipv4           1.1.1.4        40
sonic(config-tam)# no collector cnew
sonic(config-tam)# do show tam collector
------------------------------------------------------------------------------------------------
NAME           IP TYPE        IP ADDRESS     PORT
------------------------------------------------------------------------------------------------
c1             ipv4           1.1.1.1        10
c99            ipv4           1.1.1.1        990
sonic(config-tam)#
sonic(config-tam)# do show tam device
---------------------------------------------------------
TAM Device Information
---------------------------------------------------------
device-id: 100
sonic(config-tam)# no device-id
sonic(config-tam)# do show tam device
---------------------------------------------------------
TAM Device Information
---------------------------------------------------------
device-id: 0


```

The second one is to enforce matching address/type pairs with tam collector. A must statement is added to enforce that user could only enter ipv6 address (with :: delimiter) when type is selected as ipv6 and ipv4 address with type as ipv4.

```
sonic(config-tam)# collector c0072 ip-type ipv4 ip-addr 1::2 port 10
%Error: Wrong ipaddress for the specified ipaddress-type 
sonic(config-tam)# collector c0072 ip-type ipv6 ip-addr 1.1.1.2 port 10
%Error: Wrong ipaddress for the specified ipaddress-type
sonic(config-tam)# collector c0072 ip-type ipv6 ip-addr 1::2 port 10
sonic(config-tam)#

```

The third is to change the parameter name for collector command to be "type" instead of "ip-type"