### PR TITLE
Delete user when we fail to generate certificates

### DIFF
--- a/src/ham/hamd/etc/sonic/hamd/config
+++ b/src/ham/hamd/etc/sonic/hamd/config
@@ -49,13 +49,13 @@
 #   Use $$ to insert a literal $.
 #
 # type: string
-#certgen=/usr/bin/openssl req -newkey rsa:2048 -nodes -keyout $CERTDIR/key.pem -x509 -days 358000 -out $CERTDIR/certificate.pem -subj "/C=/ST=/L=/O=/CN=$USERNAME"
+#certgen=/usr/bin/openssl req -newkey rsa:2048 -nodes -keyout $CERTDIR/key.pem -subj "/O=SONiC/OU=CLI/CN=$USERNAME" | /usr/bin/openssl x509 -req -days 365000 -out $CERTDIR/certificate.pem -CA /root/cli-ca/certificate.pem -CAkey /root/cli-ca/key.pem -CAcreateserial -sha256
 
 # ==============================================================================
 # Parameter: shell
 #   Shell program used when creating new users.
 #
 # type: string
-#shell=/usr/bin/run-klish-in-mgmt-framework.py
+#shell=/usr/bin/sonic-cli
 
 

--- a/src/ham/hamd/hamd.cpp
+++ b/src/ham/hamd/hamd.cpp
@@ -27,8 +27,6 @@
     typedef std::experimental::filesystem::path   path_t;
 #endif // __GNUC_PREREQ(8,0)
 
-//#define EXTRA_DEBUG
-
 int change_credentials(uid_t uid, gid_t gid)
 {
     int rv;
@@ -166,19 +164,9 @@ std::string hamd_c::certgen(const std::string  & login) const
     // Generate certificates
     std::string cmd = config_rm.certgen_cmd(login, certdir.native());
 
-#ifdef EXTRA_DEBUG
-printf("cmd=%s\n", cmd.c_str());
-#endif
-
     LOG_CONDITIONAL(is_tron(), LOG_DEBUG, "hamd_c::certgen() - Generate user \"%s\" certificates [%s]", login.c_str(), cmd.c_str());
 
     auto [ rc, std_out, std_err ] = run(cmd);
-
-#ifdef EXTRA_DEBUG
-printf("rc     = %d\n", rc);
-printf("stdout = %s\n", std_out.c_str());
-printf("stderr = %s\n", std_err.c_str());
-#endif
 
     LOG_CONDITIONAL(is_tron(), LOG_DEBUG, "hamd_c::certgen() - Generate user \"%s\" certificates rc=%d, stdout=%s, stderr=%s",
                     login.c_str(), rc, std_out.c_str(), std_err.c_str());
@@ -235,6 +223,9 @@ static std::string roles_as_string(const std::vector< std::string > & roles)
                                                     const std::vector< std::string > & roles,
                                                     const std::string                & hashed_pw)
 {
+    std::string errmsg  = "";
+    bool        success = false;
+
     ::DBus::Struct< bool,       /* success */
                     std::string /* errmsg  */ > ret;
 
@@ -255,31 +246,38 @@ static std::string roles_as_string(const std::vector< std::string > & roles)
 
     LOG_CONDITIONAL(is_tron(), LOG_DEBUG, "hamd_c::useradd() - Create user \"%s\" [%s]", login.c_str(), cmd.c_str());
 
-#ifdef EXTRA_DEBUG
-printf("cmd=%s\n", cmd.c_str());
-#endif
-
     auto [ rc, std_out, std_err ] = run(cmd);
-
-#ifdef EXTRA_DEBUG
-printf("rc     = %d\n", rc);
-printf("stdout = %s\n", std_out.c_str());
-printf("stderr = %s\n", std_err.c_str());
-#endif
 
     LOG_CONDITIONAL(is_tron(), LOG_DEBUG, "hamd_c::useradd() - Create user \"%s\" rc=%d, stdout=%s, stderr=%s",
                     login.c_str(), rc, std_out.c_str(), std_err.c_str());
 
     if (rc == 0)
     {
-        ret._2 = certgen(login);
-        ret._1 = 0 == ret._2.length();
+        errmsg  = certgen(login);
+        success = 0 == errmsg.length(); // The errmsg should be empty on success
+
+        if (!success)
+        {
+            // Since we failed to generate the certificates,
+            // we now need to delete the user.
+            cmd = "/usr/sbin/userdel --force --remove " + login;
+
+            LOG_CONDITIONAL(is_tron(), LOG_DEBUG, "hamd_c::useradd() - executing command \"%s\"", cmd.c_str());
+
+            auto [ rc, std_out, std_err ] = run(cmd);
+
+            LOG_CONDITIONAL(is_tron(), LOG_DEBUG, "hamd_c::useradd() - command returned rc=%d, stdout=%s, stderr=%s",
+                            rc, std_out.c_str(), std_err.c_str());
+        }
     }
     else
     {
-        ret._2 = std_err;
-        ret._1 = false;
+        success = false;
+        errmsg  = std_err;
     }
+
+    ret._1 = success;
+    ret._2 = errmsg;
 
     return ret;
 }
@@ -612,9 +610,8 @@ bool hamd_c::add_unconfirmed_user(const std::string& username, const uint32_t& p
     std::string  full_cmd;
     std::string  base_cmd = "/usr/sbin/useradd"
                             " --create-home"
-                            " --no-user-group"
-                            " --shell /usr/bin/klish"
                             " --user-group"
+                            " --shell " + config_rm.shell() +
                             " --comment \"Unconfirmed system-assigned credentials " + std::to_string(pid) + '"';
 
     for (n_tries = 0; n_tries < 100; n_tries++) /* Give up retrying eventually */
@@ -735,26 +732,12 @@ std::string hamd_c::troff()
  */
 std::string hamd_c::show()
 {
-    std::ostringstream  dbg;
-    dbg << "PID                       = " << getpid() << '\n'
-        << "conf_file_pm              = " << config_rm.conf_file_pm << '\n'
-        << "certgen_cmd_m             = " << config_rm.certgen_cmd_m << '\n'
-        << "poll_period_sec_m         = " << std::to_string(config_rm.poll_period_sec_m)  << "s\n"
-        << "poll_timer_m              = " << poll_timer_m << '\n'
-        << "sac_uid_min_m             = " << std::to_string(config_rm.sac_uid_min_m) << '\n'
-        << "sac_uid_max_m             = " << std::to_string(config_rm.sac_uid_max_m) << '\n'
-        << "sac_uid_range_m           = " << std::to_string(config_rm.sac_uid_range_m)  << '\n'
-        << "shell_m                   = " << config_rm.shell_m << '\n'
-        << "tron_m                    = " << true_false(config_rm.tron_m) << '\n';
-        //<< "\n"
-        //<< "Defaults:                 = "
-        //<< "conf_file_default_pm      = " << config_rm.conf_file_default_pm << '\n'
-        //<< "certgen_cmd_default_m     = " << config_rm.certgen_cmd_default_m << '\n'
-        //<< "poll_period_sec_default_m = " << std::to_string(config_rm.poll_period_sec_default_m)  << "s\n"
-        //<< "sac_uid_min_default_m     = " << std::to_string(config_rm.sac_uid_min_default_m) << '\n'
-        //<< "sac_uid_max_default_m     = " << std::to_string(config_rm.sac_uid_max_default_m) << '\n'
-        //<< "shell_default_m           = " << config_rm.shell_default_m << '\n'
-        //<< "tron_default_m            = " << (config_rm.tron_default_m ? "true" : "false") << '\n';
+    std::ostringstream  oss;
+    oss << "Process data:\n"
+        << "  PID                       = " << getpid() << '\n'
+        << "  poll_timer_m              = " << poll_timer_m << '\n'
+        << '\n'
+        << config_rm << '\n';
 
-    return dbg.str();
+    return oss.str();
 }

--- a/src/ham/hamd/hamd.h
+++ b/src/ham/hamd/hamd.h
@@ -37,7 +37,12 @@ public:
      */
     std::string certgen_cmd(const std::string & user_r, const std::string & certdir_r) const;
 
+    std::string to_string() const;
+    bool        is_tron()   const { return tron_m; }
+
 private:
+    // PLEASE UPDATE etc/sonic/hamd/config
+    // WHEN MAKING CHANGES TO DEFAULTS
     static const  gint  poll_period_sec_default_m = 30;
     static const  gint  sac_uid_min_default_m     = 5000;  // System-Assigned IDs will be in the
     static const  gint  sac_uid_max_default_m     = 59999; // range [sac_uid_min_m..sac_uid_max_m]
@@ -47,21 +52,20 @@ private:
     std::string         shell_default_m           = "/usr/bin/sonic-cli";
 
 public:
-    bool                tron_m            = tron_default_m;
+    bool                tron_m                    = tron_default_m;
+    gint                poll_period_sec_m         = poll_period_sec_default_m;
 
-    const gchar       * conf_file_pm      = conf_file_default_pm;
+    gint                sac_uid_min_m             = sac_uid_min_default_m;  // System-Assigned IDs will be in the
+    gint                sac_uid_max_m             = sac_uid_max_default_m;  // range [sac_uid_min_m..sac_uid_max_m]
 
-    gint                poll_period_sec_m = poll_period_sec_default_m;
-
-    gint                sac_uid_min_m     = sac_uid_min_default_m;  // System-Assigned IDs will be in the
-    gint                sac_uid_max_m     = sac_uid_max_default_m;  // range [sac_uid_min_m..sac_uid_max_m]
-    gint                sac_uid_range_m   = 1 + (sac_uid_max_m - sac_uid_min_m);
-
-
-    std::string         certgen_cmd_m     = certgen_cmd_default_m;
-
-    std::string         shell_m           = shell_default_m;
+private:
+    const gchar       * conf_file_pm              = conf_file_default_pm;
+    std::string         shell_m                   = shell_default_m;
+    gint                sac_uid_range_m           = 1 + (sac_uid_max_m - sac_uid_min_m);
+    std::string         certgen_cmd_m             = certgen_cmd_default_m;
 };
+
+std::ostream & operator<<(std::ostream  & stream_r, const hamd_config_c  & obj_r);
 
 
 

--- a/src/ham/hamd/hamd_config.cpp
+++ b/src/ham/hamd/hamd_config.cpp
@@ -185,6 +185,40 @@ std::string hamd_config_c::certgen_cmd(const std::string & user_r,
 }
 
 //******************************************************************************
+std::string hamd_config_c::to_string() const
+{
+    std::ostringstream  oss;
+
+    oss << "Running config:\n"
+        << "  conf_file_pm              = " << conf_file_pm << '\n'
+        << "  certgen_cmd_m             = " << certgen_cmd_m << '\n'
+        << "  poll_period_sec_m         = " << std::to_string(poll_period_sec_m)  << "s\n"
+        << "  sac_uid_min_m             = " << std::to_string(sac_uid_min_m) << '\n'
+        << "  sac_uid_max_m             = " << std::to_string(sac_uid_max_m) << '\n'
+        << "  sac_uid_range_m           = " << std::to_string(sac_uid_range_m)  << '\n'
+        << "  shell_m                   = " << shell_m << '\n'
+        << "  tron_m                    = " << true_false(tron_m) << '\n'
+        << '\n'
+        << "Default config:\n"
+        << "  conf_file_default_pm      = " << conf_file_default_pm << '\n'
+        << "  certgen_cmd_default_m     = " << certgen_cmd_default_m << '\n'
+        << "  poll_period_sec_default_m = " << std::to_string(poll_period_sec_default_m)  << "s\n"
+        << "  sac_uid_min_default_m     = " << std::to_string(sac_uid_min_default_m) << '\n'
+        << "  sac_uid_max_default_m     = " << std::to_string(sac_uid_max_default_m) << '\n'
+        << "  shell_default_m           = " << shell_default_m << '\n'
+        << "  tron_default_m            = " << (tron_default_m ? "true" : "false");
+
+    return oss.str();
+}
+
+//******************************************************************************
+std::ostream & operator<<(std::ostream  & stream_r, const hamd_config_c  & obj_r)
+{
+    stream_r << obj_r.to_string();
+    return stream_r;
+}
+
+//******************************************************************************
 static inline char * _startswith(const char *s, const char *prefix_p, size_t prefix_l)
 {
     if (strneq(s, prefix_p, prefix_l)) return (char *)s + prefix_l - 1;
@@ -317,3 +351,6 @@ static long long numberize(const char  * str_p,
 
     return result != OK ? 0 : number;
 }
+
+
+


### PR DESCRIPTION
Delete user when we fail to generate certificates. This prevents leaving the system in a half-baked state.

I also cleaned up leftover debug statements.