### PR TITLE
specify correct depth for int-ifa sub mode

### DIFF
--- a/src/CLI/clitree/cli-xml/ifa.xml
+++ b/src/CLI/clitree/cli-xml/ifa.xml
@@ -86,7 +86,7 @@ limitations under the License.
 
   <VIEW name="config-int-ifa" 
         prompt="${SYSTEM_NAME}(config-tam-int-ifa)# " 
-        depth="2">
+        depth="3">
     <COMMAND name="no" 
              help="Negate a command or set its defaults" />
 


### PR DESCRIPTION
config-tam-int-ifa# sub mode is child of config-tam# which is child of config#
The depth of config-tam-int-ifa# should be 3 instead of 2 which causes 'exit' to switch back to config# directly instead of config-tam# as below:
sonic-mgmt(config-tam-int-ifa)# exit
sonic-mgmt(config)# exit
Correct depth, which is 3, is needed to 'exit' to config-tam# as below:
sonic-mgmt(config-tam-int-ifa)# exit
sonic-mgmt(config-tam)# exit
sonic-mgmt(config)#
