### PR TITLE
add space b/w columns in show tacacs server o/p; Use default values

### DIFF
--- a/models/yang/sonic/sonic-system-aaa.yang
+++ b/models/yang/sonic/sonic-system-aaa.yang
@@ -22,6 +22,7 @@ module sonic-system-aaa {
                 }
                 leaf failthrough {
                     type boolean;
+                    default false;
                 }
             }
         }

--- a/models/yang/sonic/sonic-system-tacacs.yang
+++ b/models/yang/sonic/sonic-system-tacacs.yang
@@ -22,6 +22,7 @@ module sonic-system-tacacs {
 
         container TACPLUS_SERVER {
             list TACPLUS_SERVER_LIST {
+                max-elements 8;
                 key "ipaddress";
 
                 leaf ipaddress {
@@ -29,16 +30,25 @@ module sonic-system-tacacs {
                 }
 
                 leaf priority {
-                    type uint8;
+                    type uint8 {
+                        range "1..64" {
+                            error-message "TACACS server priority must be 1..64";
+                        }
+                    }
                 }
 
                 leaf tcp_port {
                     type inet:port-number;
+                    default 49;
                 }
 
                 leaf timeout {
                     default 5;
-                    type uint16;
+                    type uint16 {
+                        range "1..60" {
+                            error-message "TACACS server timeout must be 1..60";
+                        }
+                    }
                 }
 
                 leaf auth_type {
@@ -75,7 +85,11 @@ module sonic-system-tacacs {
                 }
 
                 leaf timeout {
-                    type uint16;
+                    type uint16 {
+                        range "1..60" {
+                            error-message "TACACS timeout must be 1..60";
+                        }
+                    }
                     default 5;
                 }
 

--- a/src/CLI/actioner/sonic-cli-aaa.py
+++ b/src/CLI/actioner/sonic-cli-aaa.py
@@ -32,7 +32,7 @@ def invoke_api(func, args):
     api = cc.ApiClient()
 
     # Set/Get aaa configuration
-    body = { "openconfig-system-ext:failthrough": False, "openconfig-system-ext:authentication-method": ['local'] }
+    body = { "openconfig-system-ext:failthrough": False, "openconfig-system:authentication-method": ['local'] }
     failthrough='None'
     authmethod=[]
 
@@ -48,7 +48,7 @@ def invoke_api(func, args):
             if 'failthrough' in api_response['openconfig-system:config']:
                 body["openconfig-system-ext:failthrough"] = api_response['openconfig-system:config']['failthrough']
             if 'authentication-method' in api_response['openconfig-system:config']:
-                body["openconfig-system-ext:authentication-method"] = api_response['openconfig-system:config']['authentication-method']
+                body["openconfig-system:authentication-method"] = api_response['openconfig-system:config']['authentication-method']
     if func == 'put_openconfig_system_ext_system_aaa_authentication_config_failthrough':
        path = cc.Path('/restconf/data/openconfig-system:system/aaa/authentication/config/openconfig-system-ext:failthrough')
        body["openconfig-system-ext:failthrough"] = (args[0] == "True")
@@ -67,7 +67,7 @@ def invoke_api(func, args):
                authmethod.append(args[1])
        else:
            pass
-       body["openconfig-system-ext:authentication-method"] = authmethod
+       body["openconfig-system:authentication-method"] = authmethod
        return api.put(path, body)
     elif func == 'get_openconfig_system_system_aaa_authentication_config':
        return get_response

--- a/src/CLI/actioner/sonic-cli-aaa.py
+++ b/src/CLI/actioner/sonic-cli-aaa.py
@@ -32,7 +32,7 @@ def invoke_api(func, args):
     api = cc.ApiClient()
 
     # Set/Get aaa configuration
-    body = { "openconfig-system-ext:failthrough": False, "openconfig-system-ext:authentication-method": 'None' }
+    body = { "openconfig-system-ext:failthrough": False, "openconfig-system-ext:authentication-method": ['local'] }
     failthrough='None'
     authmethod=[]
 

--- a/src/CLI/clitree/cli-xml/aaa.xml
+++ b/src/CLI/clitree/cli-xml/aaa.xml
@@ -105,6 +105,11 @@ limitations under the License.
       </PARAM>
       <ACTION> python $SONIC_CLI_ROOT/sonic-cli-aaa.py put_openconfig_system_system_aaa_authentication_config_authentication_method ${login} ${local} ${tacacs+} </ACTION>
     </COMMAND>
+    <COMMAND name="no aaa" help="Unconfigure aaa authentication configuration"/>
+    <COMMAND name="no aaa authentication" help="Unconfigure aaa authentication configuration"/>
+    <COMMAND name="no aaa authentication login-method" help="Unconfigure aaa authentication login method">
+      <ACTION>python $SONIC_CLI_ROOT/sonic-cli-aaa.py put_openconfig_system_system_aaa_authentication_config_authentication_method local</ACTION>
+    </COMMAND>
   </VIEW>
 
 </CLISH_MODULE>

--- a/src/CLI/clitree/cli-xml/tacacs.xml
+++ b/src/CLI/clitree/cli-xml/tacacs.xml
@@ -79,11 +79,11 @@ limitations under the License.
              optional="true"> 
       </PARAM>
       <ACTION> 
-        if test -z "${address}"; then;
+        if test -z "${address}"; then
           python $SONIC_CLI_ROOT/sonic-cli-tacacs.py get_sonic_tacacs_server show_tacacs_server.j2;
-        else;
+        else
           python $SONIC_CLI_ROOT/sonic-cli-tacacs.py get_sonic_tacacs_server ${address} show_tacacs_server.j2;
-        fi;
+        fi
       </ACTION>
     </COMMAND>
   </VIEW>
@@ -154,7 +154,8 @@ limitations under the License.
       <PARAM name="port"
              help="server port"
              ptype="SUBCOMMAND"
-             mode="subcommand">
+             mode="subcommand"
+             optional="true">
         <PARAM name="port-val"
                help="server Port"
                ptype="TACACS_AUTH_PORT">
@@ -164,7 +165,8 @@ limitations under the License.
       <PARAM name="timeout"
              help="server timeout"
              ptype="SUBCOMMAND"
-             mode="subcommand">
+             mode="subcommand"
+             optional="true">
         <PARAM name="timeout-val"
                help="server timeout"
                ptype="TACACS_TIMEOUT">
@@ -174,7 +176,8 @@ limitations under the License.
       <PARAM name="key"
              help="server key"
              ptype="SUBCOMMAND"
-             mode="subcommand">
+             mode="subcommand"
+             optional="true">
         <PARAM name="key-val"
                help="server key"
                ptype="TACACS_KEY">
@@ -184,7 +187,8 @@ limitations under the License.
       <PARAM name="type"
              help="server authentication type"
              ptype="SUBCOMMAND"
-             mode="subcommand">
+             mode="subcommand"
+             optional="true">
         <PARAM name="type-val"
                help="server authentication type"
                ptype="AAA_AUTH_TYPE">
@@ -194,14 +198,15 @@ limitations under the License.
       <PARAM name="priority"
              help="server priority"
              ptype="SUBCOMMAND"
-             mode="subcommand">
+             mode="subcommand"
+             optional="true">
         <PARAM name="priority-val"
                help="server priority"
                ptype="TACACS_PRIORITY">
         </PARAM>
       </PARAM>
 
-      <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_tacacs_server ${host} ${port-val} ${key-val} ${timeout-val} ${type-val} ${priority-val}</ACTION>
+      <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_tacacs_server ${host} port:${port-val} key:${key-val} timeout:${timeout-val} authtype:${type-val} priority:${priority-val}</ACTION>
     </COMMAND>
 
     <!-- no tacacs server -->
@@ -225,12 +230,12 @@ limitations under the License.
 
     <COMMAND name="no tacacs-server timeout"
              help="Unconfigure global timeout for TACACS">
-      <ACTION> python $SONIC_CLI_ROOT/sonic-cli-tacacs.py delete_openconfig_system_ext_system_aaa_server_groups_server_group_config_timeout</ACTION>
+      <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_timeout 5</ACTION>
     </COMMAND>
 
     <COMMAND name="no tacacs-server auth-type"
              help="Unconfigure global auth-type for TACACS">
-      <ACTION> python $SONIC_CLI_ROOT/sonic-cli-tacacs.py delete_openconfig_system_ext_system_aaa_server_groups_server_group_config_auth_type</ACTION>
+      <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_auth_type pap</ACTION>
     </COMMAND>
 
     <COMMAND name="no tacacs-server key"

--- a/src/CLI/renderer/templates/show_tacacs_server.j2
+++ b/src/CLI/renderer/templates/show_tacacs_server.j2
@@ -7,7 +7,7 @@
 
 {% if json_output -%}
 ------------------------------------------------------------------------------------------------
-{{'%-20s'|format("HOST")}}{{'%-15s'|format("AUTH-TYPE")}}{{'%-10s'|format("KEY")}}{{'%-10s'|format("PORT")}}{{'%-10s'|format("PRIORITY")}}{{'%-10s'|format("TIMEOUT")}}
+{{'%-20s'|format("HOST")}} {{'%-15s'|format("AUTH-TYPE")}} {{'%-10s'|format("KEY")}} {{'%-10s'|format("PORT")}} {{'%-10s'|format("PRIORITY")}} {{'%-10s'|format("TIMEOUT")}}
 ------------------------------------------------------------------------------------------------
 {% set server_list = json_output %}
 
@@ -18,7 +18,7 @@
     {% if vars.update({'port':server["port"]}) %}{% endif %}
     {% if vars.update({'priority':server["priority"]}) %}{% endif %}
     {% if vars.update({'timeout':server["timeout"]}) %}{% endif %}
-{{'%-20s'|format(vars.address)}}{{'%-15s'|format(vars.authtype)}}{{'%-10s'|format(vars.key)}}{{'%-10s'|format(vars.port)}}{{'%-10s'|format(vars.priority)}}{{'%-10s'|format(vars.timeout)}}
+{{'%-20s'|format(vars.address)}} {{'%-15s'|format(vars.authtype)}} {{'%-10s'|format(vars.key)}} {{'%-10s'|format(vars.port)}} {{'%-10s'|format(vars.priority)}} {{'%-10s'|format(vars.timeout)}}
 {% endfor %}
 
 {% endif %}


### PR DESCRIPTION
This PR contains few changes:
1. Spaces b/w columns of show tacacs-server host
2. Declare default values
3. No commands would set those parameters with default values instead of deleting the record.
4. few cosmetic changes.
5. tacacs-server host now has optional parameters. Earlier, they were mandatory. 