### PR TITLE
"show ip bgp" commands 

### DIFF
--- a/src/CLI/actioner/cli_client.py
+++ b/src/CLI/actioner/cli_client.py
@@ -35,7 +35,7 @@ class ApiClient(object):
         """
         Create a RESTful API client.
         """
-        self.api_uri = os.getenv('REST_API_ROOT', 'https://localhost:8443')
+        self.api_uri = os.getenv('REST_API_ROOT', 'https://localhost:443')
 
         self.checkCertificate = False
 

--- a/src/CLI/actioner/cli_client.py
+++ b/src/CLI/actioner/cli_client.py
@@ -35,7 +35,7 @@ class ApiClient(object):
         """
         Create a RESTful API client.
         """
-        self.api_uri = os.getenv('REST_API_ROOT', 'https://localhost:443')
+        self.api_uri = os.getenv('REST_API_ROOT', 'https://localhost:8443')
 
         self.checkCertificate = False
 

--- a/src/CLI/actioner/sonic-cli-bgp.py
+++ b/src/CLI/actioner/sonic-cli-bgp.py
@@ -21,10 +21,11 @@ import sys
 import time
 import json
 import ast
+import netaddr
 from rpipe_utils import pipestr
 import cli_client as cc
 from scripts.render_cli import show_cli_output
-from bgp_openconfig_to_restconf_map import restconf_map 
+from bgp_openconfig_to_restconf_map import restconf_map
 
 IDENTIFIER='BGP'
 NAME1='bgp'
@@ -97,23 +98,29 @@ OCEXTPREFIX_PATCH_LEN=len(OCEXTPREFIX_PATCH)
 OCEXTPREFIX_DELETE='DELETE'
 OCEXTPREFIX_DELETE_LEN=len(OCEXTPREFIX_DELETE)
 
+def getPrefix(item):
+    ip = netaddr.IPNetwork(item['prefix'])
+    return int(ip.ip)
+
 def generate_show_bgp_routes(args):
    api = cc.ApiClient()
    keypath = []
    body = None
    afisafi = "IPV4_UNICAST"
+   rib_type = "ipv4-unicast"
    vrf = "default"
    neighbour_ip = ''
    route_option = 'loc-rib'
-   print args
    i = 0
    for arg in args:
         if "vrf" == arg:
            vrf = args[i+1]
         elif "ipv4" == arg:
            afisafi = "IPV4_UNICAST"
+           rib_type = "ipv4-unicast"
         elif "ipv6" == arg:
            afisafi = "IPV6_UNICAST"
+           rib_type = "ipv6-unicast"
         elif "neighbors" == arg:
            neighbour_ip = args[i+1]
            route_option = args[i+2]
@@ -124,58 +131,71 @@ def generate_show_bgp_routes(args):
         else:
            pass
         i = i + 1
-   print vrf 
-   print afisafi
-   print neighbour_ip
-   print route_option
    d = {}
    if route_option == "loc-rib":
-      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/ipv4-unicast/loc-rib', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi)
+      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
       response = api.get(keypath)
       if(response.ok()):
          d.update(response.content)
-         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
+         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/{type_name}/loc-rib', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, type_name=rib_type)
          response1 = api.get(keypath)
          if(response1.ok()):
-            d.update(response1.content)
-      show_cli_output("show_ip_bgp_routes.j2", d)
+            if 'openconfig-network-instance:loc-rib' in response1.content:
+               route = response1.content['openconfig-network-instance:loc-rib']['routes']
+               tup = route['route']
+               route['route'] = sorted(tup, key=getPrefix)
+               response1.content['openconfig-network-instance:loc-rib']['routes'] = route
+               d.update(response1.content)
+               show_cli_output("show_ip_bgp_routes.j2", d)
 
    elif route_option == "routes":
-      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/ipv4-unicast/neighbors/neighbor={nbr_address}/adj-rib-in-post', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, nbr_address = neighbour_ip)
+      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
       response = api.get(keypath)
       if(response.ok()):
          d.update(response.content)
-         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
+         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/{type_name}/neighbors/neighbor={nbr_address}/adj-rib-in-post', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, type_name=rib_type, nbr_address = neighbour_ip)
          response1 = api.get(keypath)
          if(response1.ok()):
-            d.update(response1.content)
-      print "nbr adj-rib-in-post response"
-      show_cli_output("show_ip_bgp_routes.j2", d)
+            if 'openconfig-network-instance:adj-rib-in-post' in response1.content:
+               route = response1.content['openconfig-network-instance:adj-rib-in-post']['routes']
+               tup = route['route']
+               route['route'] = sorted(tup, key=getPrefix)
+               response1.content['openconfig-network-instance:adj-rib-in-post']['routes'] = route
+               d.update(response1.content)
+               show_cli_output("show_ip_bgp_routes.j2", d)
    elif route_option == "received-routes":
-      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/ipv4-unicast/neighbors/neighbor={nbr_address}/adj-rib-in-pre', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, nbr_address = neighbour_ip)
+      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
       response = api.get(keypath)
-      if(response.ok()):
-         d.update(response.content)
-         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
-         response1 = api.get(keypath)
-         if(response1.ok()):
+      d.update(response.content)
+      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/{type_name}/neighbors/neighbor={nbr_address}/adj-rib-in-pre', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, type_name=rib_type, nbr_address = neighbour_ip)
+      response1 = api.get(keypath)
+      if(response1.ok()):
+         if 'openconfig-network-instance:adj-rib-in-pre' in response1.content:
+            route = response1.content['openconfig-network-instance:adj-rib-in-pre']['routes']
+            tup = route['route']
+            route['route'] = sorted(tup, key=getPrefix)
+            response1.content['openconfig-network-instance:adj-rib-in-pre']['routes'] = route
             d.update(response1.content)
-      print "adj-rib-in-pre response"
-      show_cli_output("show_ip_bgp_routes.j2", d)
+            show_cli_output("show_ip_bgp_routes.j2", d)
 
    elif route_option == "advertised-routes":
-      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/ipv4-unicast/neighbors/neighbor={nbr_address}/adj-rib-out-post', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, nbr_address = neighbour_ip)
+      keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
       response = api.get(keypath)
       if(response.ok()):
          d.update(response.content)
-         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=vrf, identifier=IDENTIFIER,name1=NAME1)
+         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/rib/afi-safis/afi-safi={afi_safi_name}/{type_name}/neighbors/neighbor={nbr_address}/adj-rib-out-post', name=vrf, identifier=IDENTIFIER, name1=NAME1, afi_safi_name=afisafi, type_name=rib_type, nbr_address = neighbour_ip)
          response1 = api.get(keypath)
          if(response1.ok()):
-            d.update(response1.content)
-      print "adj-rib-out-post response"
-      show_cli_output("show_ip_bgp_routes.j2", d)
+            if 'openconfig-network-instance:adj-rib-out-post' in response1.content:
+               route = response1.content['openconfig-network-instance:adj-rib-out-post']['routes']
+               tup = route['route']
+               route['route'] = sorted(tup, key=getPrefix)
+               response1.content['openconfig-network-instance:adj-rib-out-post']['routes'] = route
+               d.update(response1.content)
+               show_cli_output("show_ip_bgp_routes.j2", d)
    else:
        pass
+
    return d
 
 def invoke_api(func, args=[]):

--- a/src/CLI/actioner/sonic-cli-bgp.py
+++ b/src/CLI/actioner/sonic-cli-bgp.py
@@ -1319,11 +1319,11 @@ def invoke_show_api(func, args=[]):
 
     elif func == 'get_ip_bgp_summary':
         d = {}
-        keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name='default', identifier=IDENTIFIER, name1=NAME1)
+        keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/global/config', name=args[1], identifier=IDENTIFIER, name1=NAME1)
         response = api.get(keypath)
         if response.ok():
             d.update(response.content)
-            keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/neighbors', name='default', identifier=IDENTIFIER, name1=NAME1)
+            keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/neighbors', name=args[1], identifier=IDENTIFIER, name1=NAME1)
             response = api.get(keypath)
             if response.ok():
                 d.update(response.content)
@@ -1337,13 +1337,28 @@ def invoke_show_api(func, args=[]):
 
     elif func == 'get_ip_bgp_neighbors':
         d = {}
-        keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/neighbors', name='default', identifier=IDENTIFIER, name1=NAME1)
-        response = api.get(keypath)
-        if response.ok():
-            d.update(response.content)
-            return d
+
+        if len(args) == 3:
+            keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/neighbors/neighbor={nbr_addr}', name=args[1], identifier=IDENTIFIER, name1=NAME1, nbr_addr=args[2])
+            response = api.get(keypath)
+            if response.ok():
+                tmp = {}
+                tmp['neighbor'] = response.content['openconfig-network-instance:neighbor']
+                d['openconfig-network-instance:neighbors'] = tmp
+                d.update(response.content)
+                return d
+            else:
+                print response.error_message()
+
         else:
-            print response.error_message()
+            keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/protocols/protocol={identifier},{name1}/bgp/neighbors', name=args[1], identifier=IDENTIFIER, name1=NAME1)
+        
+            response = api.get(keypath)
+            if response.ok():
+                d.update(response.content)
+                return d
+            else:
+                print response.error_message()
 
         return d
 

--- a/src/CLI/clitree/cli-xml/bgp.xml
+++ b/src/CLI/clitree/cli-xml/bgp.xml
@@ -29,7 +29,7 @@ limitations under the License.
     <PARAM name="bgp subcommands" help="BGP Subcommands" ptype="SUBCOMMAND" mode="switch" optional="true">
        <MACRO name="IP_BGP_SUB_CMDS" arg=""></MACRO>
        <PARAM name="vrf" help="BGP VRF" mode="subcommand" ptype="SUBCOMMAND" optional="true">
-         <PARAM name="vrf-Name" help="VRF Name" ptype="STRING">
+         <PARAM name="vrf-name" help="VRF Name" ptype="STRING" default="default">
            <PARAM name="ip subcommands" help="IP subcommands" ptype="SUBCOMMAND" mode="switch" optional="true">
            <MACRO name="IP_BGP_SUB_CMDS" arg=""></MACRO>
            </PARAM>
@@ -38,7 +38,7 @@ limitations under the License.
     </PARAM>
     <ACTION>
         if test -n "${summary}"; then&#xA;
-           python $SONIC_CLI_ROOT/sonic-cli-bgp.py get_ip_bgp_summary show_ip_bgp_summary.j2&#xA;
+           python $SONIC_CLI_ROOT/sonic-cli-bgp.py get_ip_bgp_summary show_ip_bgp_summary.j2 ${vrf-name}&#xA;
         elif test -n "${prefix}"; then&#xA;
            builtin="clish_nop"&#xA;
         elif test -n "${peer-group}"; then&#xA;
@@ -47,7 +47,7 @@ limitations under the License.
            if test -n "${neighbor-subcommands}"; then&#xA;
               python $SONIC_CLI_ROOT/sonic-cli-bgp.py get_show_bgp ${__full_line}&#xA;
            else&#xA;
-              python $SONIC_CLI_ROOT/sonic-cli-bgp.py get_ip_bgp_neighbors show_ip_bgp_neighbors.j2&#xA;
+              python $SONIC_CLI_ROOT/sonic-cli-bgp.py get_ip_bgp_neighbors show_ip_bgp_neighbors.j2 ${vrf-name} ${neighbor-ip}&#xA;
            fi&#xA;
         else&#xA;
            python $SONIC_CLI_ROOT/sonic-cli-bgp.py get_show_bgp ${__full_line}&#xA;

--- a/src/CLI/renderer/templates/show_ip_bgp_neighbors.j2
+++ b/src/CLI/renderer/templates/show_ip_bgp_neighbors.j2
@@ -26,12 +26,6 @@
             {{-', keepalive interval is '}}{{n_timers_state['keepalive-interval']}}{{' seconds\n'}}
             {{-'  Neighbor capabilities:\n'}}
             {{-'    4 Byte AS: advertised and received\n'}}
-            {{-'    AddPath:\n'}} 
-            {{-'      IPv4 Unicast: RX advertised IPv4 Unicast\n'}}
-            {{-'    Route refresh: advertised and received(old & new)\n'}}
-            {{-'    Address Family IPv4 Unicast: advertised and received\n'}}
-            {{-'    Hostname Capability: advertised (name: sonic,domain name: n/a) not received\n'}}
-            {{-'    Graceful Restart Capabilty: advertised\n'}}
             {% if 'queues' in n_state %}
                 {% set n_queues = n_state['queues'] %}
                 {{-'  Message statistics:\n'}}

--- a/src/CLI/renderer/templates/show_ip_bgp_routes.j2
+++ b/src/CLI/renderer/templates/show_ip_bgp_routes.j2
@@ -7,7 +7,9 @@
 {% set vars = {'locPref': ""} %}
 {% set vars = {'origin': "IGP"} %}
 {% set vars = {'weight': "0"} %}
-{% set vars = {'validRoute': ""} %}
+{% set vars = {'validRoute': False} %}
+{% set vars = {'bestRoute': False} %}
+{% set vars = {'members': ""} %}
 {% if json_output -%}
 {% for key in json_output %}
 {% if "openconfig-network-instance:config" in key %}
@@ -18,11 +20,9 @@
 {% endfor %}
 BGP routing table information for VRF default
 Router identifier {{ vars.routerId }}, local AS number {{ vars.asNum }} 
-Route status codes: s - suppressed, * - valid, > - active, # - not installed, E - ECMP head, e - ECMP
-                    S - stale, c - contributing to ECMP, b - backup, L - labeled-unicast
+Route status codes: * - valid, > - best
 Origin codes: i - IGP, e - EGP, ? - incomplete
-AS Path Attributes: Or-ID - Originator ID, C-LST - Cluster List, LL Nexthop - Link Local Nexthop
-     {{'%-20s'|format("Network")}}{{'%-20s'|format("Next Hop")}}{{'%-15s'|format("Metric")}}{{'%-15s'|format("LocPref")}}{{'%-15s'|format("Path")}}
+     {{'%-20s'|format("Network")}}{{'%-20s'|format("Next Hop")}}{{'%-15s'|format("Metric")}}{{'%-15s'|format("LocPref")}}{{'%s'|format("Path")}}
 {% for key in json_output %}
 {% if "openconfig-network-instance:adj-rib-in-pre" in key %}
 {% set routeList = json_output["openconfig-network-instance:adj-rib-in-pre"]["routes"]["route"] %}
@@ -33,23 +33,42 @@ AS Path Attributes: Or-ID - Originator ID, C-LST - Cluster List, LL Nexthop - Li
 {% elif "openconfig-network-instance:adj-rib-in-post" in key %}
 {% set routeList = json_output["openconfig-network-instance:adj-rib-in-post"]["routes"]["route"] %}
 {% elif "openconfig-network-instance:loc-rib" in key %}
-{% set routeList = json_output["openconfig-network-instance:adj-rib-in-post"]["routes"]["route"] %}
+{% set routeList = json_output["openconfig-network-instance:loc-rib"]["routes"]["route"] %}
 {% else %}
 {% endif %}
 {% if routeList %}
 {% for route in routeList %}
 {% for key in route %}
+  {% if vars.update({'members':''}) %} {% endif %}
   {% if vars.update({'prefix':route["prefix"]}) %}{% endif %}
   {% if vars.update({'weight':"0"}) %}{% endif %}
   {% if "state" in key %}
     {% if vars.update({'validRoute':route["state"]["valid-route"]}) %}{% endif %}
+    {% if vars.update({'bestRoute':route["state"]["best-path"]}) %}{% endif %}
     {% if vars.update({'pathId':route["state"]["path-id"]}) %}{% endif %}
   {% endif %}
   {% if "openconfig-bgp-ext:attr-sets" in key %}
-    {% if vars.update({'origin':route["openconfig-bgp-ext:attr-sets"]["origin"]}) %}{% endif %}
-    {% if vars.update({'nxtHop':route["openconfig-bgp-ext:attr-sets"]["next-hop"]}) %}{% endif %}
-    {% if vars.update({'med':route["openconfig-bgp-ext:attr-sets"]["med"]}) %}{% endif %}
-    {% if vars.update({'locPref':route["openconfig-bgp-ext:attr-sets"]["local-pref"]}) %}{% endif %}
+    {% set attr_sets = route[key] %}
+    {% if vars.update({'origin':attr_sets["origin"]}) %}{% endif %}
+    {% if vars.update({'nxtHop':attr_sets["next-hop"]}) %}{% endif %}
+    {% if vars.update({'med':attr_sets["med"]}) %}{% endif %}
+    {% if vars.update({'locPref':attr_sets["local-pref"]}) %}{% endif %}
+    {% if "as-path" in attr_sets %}
+      {% set as_path = attr_sets['as-path'] %}
+      {% if "as-segment" in as_path %}
+         {% set segements = as_path['as-segment'] %}
+         {% set temp = [] %}
+         {% for segment in segements %}
+              {% if "state" in segment %}
+                {% set mems = segment['state']['member'] %}
+                {% for mem in mems %}
+                {%  do temp.append(mem) %}
+                {% endfor %}
+              {% endif %}
+         {% endfor %}
+         {% if vars.update({'members': temp|join(" ")}) %} {% endif %}
+      {% endif %}
+    {% endif %}
   {% endif %}
   {% if vars.origin == 'IGP' %}
     {% if vars.update({'origin':"i"}) %}{% endif %}
@@ -59,12 +78,17 @@ AS Path Attributes: Or-ID - Originator ID, C-LST - Cluster List, LL Nexthop - Li
     {% if vars.update({'origin':"?"}) %}{% endif %}
   {% endif %}
 {% endfor %}
-{% if vars.validRoute == 'true' %}
+{% if vars.validRoute == True %}
 {% if vars.update({'validRoute':"*"}) %}{% endif %}
 {% else %}
 {% if vars.update({'validRoute':""}) %}{% endif %}
 {% endif %}
-{{'%-5s'|format(vars.validRoute)}}{{'%-20s'|format(vars.prefix)}}{{'%-20s'|format(vars.nxtHop)}}{{'%-15s'|format(vars.med)}}{{'%-15s'|format(vars.locPref)}}{{'%-1s'|format(vars.pathId)}} {{vars.origin}}
+{% if vars.bestRoute == True %}
+{% if vars.update({'bestRoute':">"}) %}{% endif %}
+{% else %}
+{% if vars.update({'bestRoute':""}) %}{% endif %}
+{% endif %}
+{{'%-1s'|format(vars.validRoute)}}{{'%-4s'|format(vars.bestRoute)}}{{'%-20s'|format(vars.prefix)}}{{'%-20s'|format(vars.nxtHop)}}{{'%-15s'|format(vars.med)}}{{'%-15s'|format(vars.locPref)}}{{'%s'|format(vars.members)}} {{vars.origin}}
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/src/translib/transformer/xfmr_bgp_rib.go
+++ b/src/translib/transformer/xfmr_bgp_rib.go
@@ -1113,7 +1113,6 @@ func fill_ipv4_spec_pfx_nbr_out_post_rib_data (ipv4OutPostRoute_obj *ocbinds.
     ipv4NbrOutPostRouteState.Prefix = &prefix
     ipv4NbrOutPostRouteState.PathId = &pathId
 
-    log.Info("Entry 2")
     lastUpdate, ok := prefixData["lastUpdate"].(map[string]interface{})
     if ok {
         if value, ok := lastUpdate["epoch"] ; ok {
@@ -1219,13 +1218,11 @@ func fill_bgp_ipv4_nbr_adj_rib_out_post (ipv4Nbr_obj *ocbinds.OpenconfigNetworkI
         ipv4OutPostRoutes_obj = ipv4NbrAdjRibOutPost_obj.Routes
     }
 
-    log.Info("Entry 1 ")
     for prefix, _ := range routes {
         prefixData, ok := routes[prefix].(map[string]interface{}) ; if !ok {continue}
         value, ok := prefixData["pathId"] ; if !ok {continue}
         pathId := uint32(value.(float64))
 
-        log.Info("prefixData ", prefixData, "prefix ", prefix, "pathId ", pathId)
         if (rib_key.prefix != "" && (prefix != rib_key.prefix)) {continue}
         if (rib_key.pathIdKey != "" && (pathId != rib_key.pathId)) {continue}
 
@@ -1536,7 +1533,6 @@ func hdl_get_bgp_nbrs_adj_rib_out_post (bgpRib_obj *ocbinds.OpenconfigNetworkIns
         return oper_err
     }
 
-    log.Info("NBRS-RIB ==> Got FRR response ", bgpRibOutputJson)
     if vrfName, ok := bgpRibOutputJson["vrfName"] ; (!ok || vrfName != rib_key.niName) {
         log.Errorf ("%s failed !! GET-req niName:%s not same as JSON-VRFname:%s", *dbg_log, rib_key.niName, vrfName)
         return oper_err


### PR DESCRIPTION
Supported commands and output mentioned below.

SONIC: 

sonic# show ip bgp summary
BGP router identifier 20.0.0.1, local AS number 100

Neighbor        V   AS    MsgRcvd   MsgSent   TblVer  InQ     OutQ    Up/Down                 State/PfxRcd
20.0.0.2        4   100   3         3         0       0       0       2019-12-20 19:51:37     ESTABLISHED
2222::3/64      4         0         0         0       0       0       00:00:00                0
8.8.8.8         4         0         0         0       0       0       00:00:00                0

Total number of neighbors 3


sonic# show ip bgp neighbors
BGP neighbor is 20.0.0.2, remote AS 100, local AS 200, internal link
  BGP version 4, remote router ID  , local router ID
  BGP state = ESTABLISHED, up for 2019-12-20 19:51:37
  Hold time is 180, keepalive interval is  seconds
  Neighbor capabilities:
    4 Byte AS: advertised and received
  Message statistics:
    Inq depth is 0
    Outq depth is 0
                         Sent        Rcvd
    Notifications:       0           0
    Updates:             3           3
    Total:               03          03
Local host: 20.0.0.1, Local port: 179
Foreign host: 20.0.0.2, Foreign port: 41546


sonic# show ip bgp
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
     20.0.0.0/16         20.0.0.2                                          100 234 345 3456 345 ?
*    111.0.0.0/24        0.0.0.0             0                              i
*    112.0.0.0/24        0.0.0.0             0                              i
*    113.0.0.0/24        0.0.0.0             0                              i


sonic# show ip bgp ipv6
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
*    2000:1:1:1::/64     fe80::92b1:1cff:fef4:9c58                              100 234 345 3456 345 ?
*    2000:1:1:2::/64     fe80::92b1:1cff:fef4:9c58                              100 234 345 3456 345 ?
*    2000:1:1:3::/64     fe80::92b1:1cff:fef4:9c58                              100 234 345 3456 345 ?
*    2222::/64           fe80::92b1:1cff:fef4:9c58                              100 234 345 3456 345 ?


sonic# show ip bgp neighbors 20.0.0.2 routes
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
     20.0.0.0/16         20.0.0.2                                          100 234 345 3456 345 ?
sonic# show ip bgp neighbors 20.0.0.2 received-routes
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
*    20.0.0.0/16         20.0.0.2                                          100 234 345 3456 345 ?
sonic#
sonic# show ip bgp neighbors 20.0.0.2 advertised-routes
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
     111.0.0.0/24        0.0.0.0                                            i
     112.0.0.0/24        0.0.0.0                                            i
     113.0.0.0/24        0.0.0.0                                            i


sonic# show ip bgp ipv6 neighbors 2222::2 routes
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
*>   2000:1:1:1::/64     2222::2                                           100 234 345 3456 345 ?
*>   2000:1:1:2::/64     2222::2                                           100 234 345 3456 345 ?
*>   2000:1:1:3::/64     2222::2                                           100 234 345 3456 345 ?
*>   2222::/64           2222::2                                           100 234 345 3456 345 ?
sonic#
sonic# show ip bgp ipv6 neighbors 2222::2 received-routes
sonic# show ip bgp ipv6 neighbors 2222::2 advertised-routes
BGP routing table information for VRF default
Router identifier 20.0.0.1, local AS number 100
Route status codes: * - valid, > - best
Origin codes: i - IGP, e - EGP, ? - incomplete
     Network             Next Hop            Metric         LocPref        Path
     2000:1:1:1::/64     2222::2                                           100 234 345 3456 345 ?
     2000:1:1:2::/64     2222::2                                           100 234 345 3456 345 ?
     2000:1:1:3::/64     2222::2                                           100 234 345 3456 345 ?
     2222::/64           2222::2                                           100 234 345 3456 345 ?




FRR: 

sonic# show ip bgp summary

IPv4 Unicast Summary:
BGP router identifier 20.0.0.1, local AS number 200 vrf-id 0
BGP table version 5
RIB entries 4, using 736 bytes of memory
Peers 2, using 41 KiB of memory

Neighbor        V         AS MsgRcvd MsgSent   TblVer  InQ OutQ  Up/Down State/PfxRcd
20.0.0.2        4        100     679     594        0    0    0 09:48:14            1
2222::2         4        100     689     601        0    0    0 09:45:46 NoNeg

Total number of neighbors 2
Total number of neighbors established 2


sonic# show ip bgp neighbors
BGP neighbor is 20.0.0.2, remote AS 100, local AS 200, external link
  BGP version 4, remote router ID 2.2.2.2, local router ID 20.0.0.1
  BGP state = Established, up for 09:48:34
  Last read 00:00:31, Last write 00:00:34
  Hold time is 180, keepalive interval is 60 seconds
  Neighbor capabilities:
    4 Byte AS: advertised and received
    AddPath:
      IPv4 Unicast: RX advertised IPv4 Unicast
    Route refresh: advertised and received(old & new)
    Address Family IPv4 Unicast: advertised and received
    Hostname Capability: advertised (name: sonic,domain name: n/a) not received
    Graceful Restart Capabilty: advertised
  Message statistics:
    Inq depth is 0
    Outq depth is 0
                         Sent       Rcvd
    Opens:                  2          1
    Notifications:          0          0
    Updates:                3          3
    Keepalives:           589        675
    Route Refresh:          0          0
    Capability:             0          0
    Total:                594        679
  Minimum time between advertisement runs is 0 seconds
 For address family: IPv4 Unicast
  Update group 3, subgroup 4
  Packet Queue length 0
  Inbound soft reconfiguration allowed
  Community attribute sent to this neighbor(all)
  1 accepted prefixes

  Connections established 1; dropped 0
  Last reset 09:48:56,   No AFI/SAFI activated for peer
Local host: 20.0.0.1, Local port: 179
Foreign host: 20.0.0.2, Foreign port: 41546
Nexthop: 20.0.0.1
Nexthop global: 2222::1
Nexthop local: fe80::92b1:1cff:fef4:9d50
BGP connection: shared network
BGP Connect Retry Timer in Seconds: 120
Read thread: on  Write thread: on  FD used: 25

BGP neighbor is 2222::2, remote AS 100, local AS 200, external link
  BGP version 4, remote router ID 2.2.2.2, local router ID 20.0.0.1
  BGP state = Established, up for 09:46:06
  Last read 00:00:31, Last write 00:00:06
  Hold time is 180, keepalive interval is 60 seconds
  Neighbor capabilities:
    4 Byte AS: advertised and received
    AddPath:
      IPv4 Unicast: RX advertised IPv4 Unicast
      IPv6 Unicast: RX advertised IPv6 Unicast
    Route refresh: advertised and received(old & new)
    Address Family IPv4 Unicast: advertised
    Address Family IPv6 Unicast: advertised and received
    Hostname Capability: advertised (name: sonic,domain name: n/a) not received
    Graceful Restart Capabilty: advertised
  Message statistics:
    Inq depth is 0
    Outq depth is 0
 Minimum time between advertisement runs is 0 seconds

 For address family: IPv4 Unicast
  Not part of any update group
  Community attribute sent to this neighbor(all)
  0 accepted prefixes

 For address family: IPv6 Unicast
  Update group 5, subgroup 7
  Packet Queue length 0
  Community attribute sent to this neighbor(all)
  4 accepted prefixes

  Connections established 2; dropped 1
  Last reset 09:46:08,   Notification received (Cease/Administratively Shutdown)
Local host: 2222::1, Local port: 54258
Foreign host: 2222::2, Foreign port: 179
Nexthop: 20.0.0.1
Nexthop global: 2222::1
Nexthop local: fe80::92b1:1cff:fef4:9d50
BGP connection: shared network
BGP Connect Retry Timer in Seconds: 120
Read thread: on  Write thread: on  FD used: 26


sonic# show ip bgp
BGP table version is 5, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
    20.0.0.0/16      20.0.0.2                                       0 100 234 345 3456 345 ?
*>  111.0.0.0/24     0.0.0.0                  0                 32768 i
*>  112.0.0.0/24     0.0.0.0                  0                 32768 i
*>  113.0.0.0/24     0.0.0.0                  0                 32768 i

Displayed  4 routes and 4 total paths


sonic# show ip bgp ipv6
BGP table version is 16, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
*>  2000:1:1:1::/64  fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?
*>  2000:1:1:2::/64  fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?
*>  2000:1:1:3::/64  fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?
*>  2222::/64        fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?

Displayed  4 routes and 4 total paths



sonic# show ip bgp neighbors 20.0.0.2 routes
BGP table version is 5, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
    20.0.0.0/16      20.0.0.2                                       0 100 234 345 3456 345 ?

Displayed  1 routes and 4 total paths
sonic#
sonic#
sonic# show ip bgp neighbors 20.0.0.2 received-routes
BGP table version is 0, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
*> 20.0.0.0/16      20.0.0.2                                       0 100 234 345 3456 345 ?

Total number of prefixes 1


sonic# show ip bgp neighbors 20.0.0.2 advertised-routes
BGP table version is 5, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
*> 111.0.0.0/24     0.0.0.0                  0                 32768 i
*> 112.0.0.0/24     0.0.0.0                  0                 32768 i
*> 113.0.0.0/24     0.0.0.0                  0                 32768 i

Total number of prefixes 3


sonic# show ip bgp ipv6 neighbors 2222::2  routes
BGP table version is 16, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
*>  2000:1:1:1::/64  fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?
*>  2000:1:1:2::/64  fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?
*>  2000:1:1:3::/64  fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?
*>  2222::/64        fe80::92b1:1cff:fef4:9c58
                                                                   0 100 234 345 3456 345 ?

Displayed  4 routes and 4 total paths


sonic# show ip bgp ipv6 neighbors 2222::2  received-routes
% Inbound soft reconfiguration not enabled
sonic# show ip bgp ipv6 neighbors 2222::2  advertised-routes
BGP table version is 16, local router ID is 20.0.0.1, vrf id 0
Default local pref 100, local AS 200
Status codes:  s suppressed, d damped, h history, * valid, > best, = multipath, # not installed in hardware
               i internal, r RIB-failure, S Stale, R Removed
Nexthop codes: @NNN nexthop's vrf id, < announce-nh-self
Origin codes:  i - IGP, e - EGP, ? - incomplete

   Network          Next Hop            Metric     LocPrf     Weight Path
*> 2000:1:1:1::/64  2222::2                                        0 100 234 345 3456 345 ?
*> 2000:1:1:2::/64  2222::2                                        0 100 234 345 3456 345 ?
*> 2000:1:1:3::/64  2222::2                                        0 100 234 345 3456 345 ?
*> 2222::/64        2222::2                                        0 100 234 345 3456 345 ?

Total number of prefixes 4
sonic#
