### PR TITLE
Restrict nat zone range in CLI

### DIFF
--- a/src/CLI/clitree/cli-xml/interface.xml
+++ b/src/CLI/clitree/cli-xml/interface.xml
@@ -395,7 +395,7 @@ limitations under the License.
             <PARAM
                 name="zone"
                 help="NAT zone of the interface"
-                ptype="UINT" />
+                ptype="RANGE_NAT_ZONE" />
         <ACTION>
             python $SONIC_CLI_ROOT/sonic-cli-nat.py patch_openconfig_interfaces_ext_interfaces_interface_nat_zone_config_nat_zone ${iface} ${zone}
         </ACTION>
@@ -684,7 +684,7 @@ limitations under the License.
             <PARAM
                 name="zone"
                 help="NAT zone of the vlan"
-                ptype="UINT" />
+                ptype="RANGE_NAT_ZONE" />
         <ACTION>
             python $SONIC_CLI_ROOT/sonic-cli-nat.py patch_openconfig_interfaces_ext_interfaces_interface_nat_zone_config_nat_zone ${vlan_id} ${zone}
         </ACTION>
@@ -764,7 +764,7 @@ limitations under the License.
             <PARAM
                 name="zone"
                 help="NAT zone of the port channel"
-                ptype="UINT" />
+                ptype="RANGE_NAT_ZONE" />
         <ACTION>
             python $SONIC_CLI_ROOT/sonic-cli-nat.py patch_openconfig_interfaces_ext_interfaces_interface_nat_zone_config_nat_zone ${po_name} ${zone}
         </ACTION>

--- a/src/CLI/clitree/cli-xml/sonic_types.xml
+++ b/src/CLI/clitree/cli-xml/sonic_types.xml
@@ -86,6 +86,13 @@ limitations under the License.
         />
     <!--=======================================================-->
     <PTYPE
+        name="RANGE_NAT_ZONE"
+        method="integer"
+        pattern="0..3"
+        help=""
+        />
+    <!--=======================================================-->
+    <PTYPE
         name="ON_OFF"
         method="select"
         pattern="on(true) off(false)"


### PR DESCRIPTION
**Unit Test:**

sonic# configure terminal
sonic(config)# interface Ethernet 0
sonic(conf-if-Ethernet0)# no shutdown
sonic(conf-if-Ethernet0)# mtu 1535
sonic(conf-if-Ethernet0)# description "TestEth0"
sonic(conf-if-Ethernet0)#
sonic(conf-if-Ethernet0)# nat-zone
    **NAT zone of the interface (0..3)**

sonic(conf-if-Ethernet0)# nat-zone 0
sonic(conf-if-Ethernet0)# nat-zone 1
sonic(conf-if-Ethernet0)# nat-zone 2
sonic(conf-if-Ethernet0)# nat-zone 3
sonic(conf-if-Ethernet0)# nat-zone 4
**Syntax error: Illegal parameter**
sonic(conf-if-Ethernet0)# nat-zone 5
**Syntax error: Illegal parameter**
sonic(conf-if-Ethernet0)# nat-zone 255
Syntax error: Illegal parameter
sonic(conf-if-Ethernet0)# nat-zone 256
Syntax error: Illegal parameter
sonic(conf-if-Ethernet0)# nat-zone 125
Syntax error: Illegal parameter
