### PR TITLE
Reset CURLOPT_UPLOAD when there is no body

### DIFF
--- a/src/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.c
+++ b/src/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.c
@@ -209,6 +209,8 @@ int rest_cl(char *cmd, const char *buff)
                 (curl_off_t)up_obj.sizeleft);
 
         curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+    } else {
+        curl_easy_setopt(curl, CURLOPT_UPLOAD, 0L);
     }
  
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ret);


### PR DESCRIPTION
Issue: Seeing CLISH hang when deleting a vlan.

RCA:
The issue is seen when we use a configuration command that uses the clish_restcl builtin function and has a body (example: create a vlan)  followed by using a command that uses clish_restcl with a DELETE operation.

The curl handle is being reused. When the command requires data to be uploaded to the server, we set CURLOPT_UPLOAD to 1. In the case that there is no data, CURLOPT_UPLOAD needs to be set to 0.

Fix: Set CURLOPT_UPLOAD to 0 when there is no data to upload.