### PR TITLE
[SONIC-14938] Fix default shell for management users

### DIFF
--- a/src/ham/hamd/hamd.h
+++ b/src/ham/hamd/hamd.h
@@ -46,7 +46,7 @@ private:
     std::string         certgen_default_m         = "/usr/bin/certgen";
     //std::string         shell_default_m           = "/usr/bin/sonic-cli";
     //std::string         shell_default_m           = ""; // empty string -> let linux assign default shell (as per /etc/default/useradd)
-    std::string         shell_default_m           = "/bin/bash";
+    std::string         shell_default_m           = "/usr/bin/sonic-launch-shell";
 
 public:
     bool                tron_m                    = tron_default_m;


### PR DESCRIPTION
Prior to this change, all users were getting dropped into bash. This is
a security hole, since it allows operator users write access to the
system.

This change changes the default shell to the `sonic-launch-shell`
script, which launches the correct shell for each user based on their
primary group.