### PR TITLE
[SONIC-14938] Remove system command from CLI

### DIFF
--- a/src/CLI/clitree/cli-xml/enable_mode.xml
+++ b/src/CLI/clitree/cli-xml/enable_mode.xml
@@ -74,20 +74,5 @@ limitations under the License.
         <COMMAND
             name="no debug"
             help="No Debug commands" />
-        <!-- Special commands -->
-        <COMMAND
-            name="system"
-            help="System command"
-            >
-            <PARAM
-                name="cmd"
-                help="Enter the linux command to execute"
-                ptype="STRING_WITH_PIPE"
-                >
-            </PARAM>
-            <ACTION>
-                ${cmd}
-            </ACTION>
-        </COMMAND>
     </VIEW>
 </CLISH_MODULE>


### PR DESCRIPTION
The `system` command allows users to run any arbitrary command from the
klish CLI as if they were running them from a Bash shell. This is
unacceptable and opens a security hole for non-admin users, which
permits them to drop into a shell and perform actions that would
normally not be authorized for them.

This change removes the system command altogether. Earlier commits have
changed the default shell such that admin users get dropped into Bash
and can launch `sonic-cli` manually, and everybody else gets dropped
into the CLI directly.