### PR TITLE
Support stp for port-channel interfaces and fix display issues

### DIFF
--- a/src/CLI/clitree/cli-xml/stp.xml
+++ b/src/CLI/clitree/cli-xml/stp.xml
@@ -613,7 +613,7 @@ limitations under the License.
 <VIEW name="configure-if-view">
     <COMMAND
         name="spanning-tree"
-        help = "Configure spanning tree on intreface"
+        help = "Configure spanning tree on interface"
         >
         <PARAM
             name="stp-if-subcmds"
@@ -806,7 +806,7 @@ limitations under the License.
 
     <COMMAND
         name="spanning-tree guard"
-        help = "Configure spanning tree guard on intreface"
+        help = "Configure spanning tree guard on interface"
         >
         <PARAM
             name="root"
@@ -822,7 +822,7 @@ limitations under the License.
 
     <COMMAND
         name="spanning-tree vlan"
-        help = "Configure spanning tree on intreface for VLAN"
+        help = "Configure spanning tree on interface for VLAN"
         >
         <PARAM
             name="vlan-range"
@@ -877,7 +877,7 @@ limitations under the License.
 
     <COMMAND
         name="no spanning-tree"
-        help = "Unconfigure spanning tree on intreface"
+        help = "Unconfigure spanning tree on interface"
         >
         <PARAM
             name="stp-if-subcmds"
@@ -1002,7 +1002,7 @@ limitations under the License.
 
     <COMMAND
         name="no spanning-tree guard"
-        help = "Unconfigure spanning tree guard on intreface"
+        help = "Unconfigure spanning tree guard on interface"
         >
         <PARAM
             name="root"
@@ -1018,7 +1018,7 @@ limitations under the License.
 
     <COMMAND
         name="no spanning-tree vlan"
-        help = "Unconfigure spanning tree on intreface for given VLAN"
+        help = "Unconfigure spanning tree on interface for given VLAN"
         >
         <PARAM
             name="vlan-range"
@@ -1054,6 +1054,465 @@ limitations under the License.
         python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_custom_stp_vlan_interfaces_interface_config_cost ${vlan-range} ${iface}&#xA;
         elif test "${stp-if-vlan-subcmds}" = "port-priority";then&#xA;
         python $SONIC_CLI_ROOT/sonic-cli-stp.py  delete_custom_stp_vlan_interfaces_interface_config_port_priority ${vlan-range} ${iface}&#xA;
+        fi&#xA;
+        builtin="clish_nop"
+    </ACTION>
+    </COMMAND>
+
+</VIEW>
+
+<!-- Config lag mode -->
+<VIEW name="configure-lag-view">
+    <COMMAND
+        name="spanning-tree"
+        help = "Configure spanning tree on port-channel"
+        >
+        <PARAM
+            name="stp-if-subcmds"
+            help="spannig tree port-channel subcommands"
+            ptype="SUBCOMMAND"
+            mode="switch"
+            >
+            <PARAM
+                name="bpduguard"
+                help="Enables bpdu guard on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="port-shutdown"
+                    help="Enable port shutdown on bpdu guard violation"
+                    ptype="SUBCOMMAND"
+                    mode="subcommand"
+                    optional="true"
+                    >
+                </PARAM>
+            </PARAM>
+            <PARAM
+                name="cost"
+                help="Set the port level cost"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="value"
+                    help="Port cost value"
+                    ptype="STP_COST"
+                    >
+                </PARAM>
+            </PARAM>
+            <PARAM
+                name="enable"
+                help="Enables spanning-tree on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+            <PARAM
+                name="link-type"
+                help="Set link type of the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="link-sub-cmds"
+                    help = "link type sub commands."
+                    ptype="SUBCOMMAND"
+                    mode="switch"
+                    >
+                    <PARAM
+                        name="auto"
+                        help = "link type is set based on the duplex setting of the port-channel."
+                        ptype="SUBCOMMAND"
+                        mode="subcommand"
+                        >
+                    </PARAM>
+                    <PARAM
+                        name="point-to-point"
+                        help = "link type of given port-channel is point-to-point."
+                        ptype="SUBCOMMAND"
+                        mode="subcommand"
+                        >
+                    </PARAM>
+                    <PARAM
+                        name="shared"
+                        help = "link type of given port-channel is shared."
+                        ptype="SUBCOMMAND"
+                        mode="subcommand"
+                        >
+                    </PARAM>
+                </PARAM>
+            </PARAM>
+            <PARAM
+                name="portfast"
+                help="Enables portfast on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="port-priority"
+                help="Set the port level priority"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="value"
+                    help="Port priority value"
+                    ptype="STP_PORT_PRIORITY"
+                    >
+                </PARAM>
+            </PARAM>
+
+            <PARAM
+                name="port"
+                help="Set Spanning tree port"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="type"
+                    help="Spanning Tree port type"
+                    ptype="SUBCOMMAND"
+                    mode="subcommand"
+                    >
+                    <PARAM
+                        name="edge"
+                        help="Edge port"
+                        ptype="SUBCOMMAND"
+                        mode="subcommand"
+                        >
+                    </PARAM>
+                </PARAM>
+            </PARAM>
+
+        <PARAM
+            name="uplinkfast"
+            help="Enables uplink fast on the port-channel"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+            >
+        </PARAM>
+    </PARAM>
+    <ACTION>
+        if test "${stp-if-subcmds}" = "bpduguard";then&#xA;
+            if test "${port-shutdown}" != "";then&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_bpdu_guard_port_shutdown ${po_name} True&#xA;
+            else&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_guard ${po_name} True&#xA;
+            fi&#xA;
+        elif test "${stp-if-subcmds}" = "portfast";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_portfast ${po_name} True&#xA;
+        elif test "${stp-if-subcmds}" = "uplinkfast";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_uplink_fast ${po_name} True&#xA;
+        elif test "${stp-if-subcmds}" = "enable";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_spanning_tree_enable ${po_name} True&#xA;
+        elif test "${stp-if-subcmds}" = "cost";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_cost ${po_name} ${value}&#xA;
+        elif test "${stp-if-subcmds}" = "port-priority";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_port_priority ${po_name} ${value}&#xA;
+        elif test "${stp-if-subcmds}" = "link-type";then&#xA;
+            if test "${link-sub-cmds}" = "auto";then&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name}&#xA;
+            elif test "${link-sub-cmds}" = "point-to-point";then&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name} "P2P"&#xA;
+            elif test "${link-sub-cmds}" = "shared";then&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name} "SHARED"&#xA;
+            fi&#xA;
+        elif test "${stp-if-subcmds}" = "port";then&#xA;
+            if test "${edge}" != "";then&#xA;
+            python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_edge_port ${po_name} True&#xA;
+            fi&#xA;
+        fi&#xA;
+        builtin="clish_nop"
+    </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="spanning-tree bpdufilter"
+        help="Spanning-tree BPDU filter on the port-channel"
+        >
+        <PARAM
+            name="bpdufilt_sub_cmds"
+            help="Spanning-tree BPDU filter subcommands"
+            ptype="SUBCOMMAND"
+            mode="switch"
+            >
+            <PARAM
+                name="enable"
+                help="Enables spanning-tree BPDU filter on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+            <PARAM
+                name="disable"
+                help="Disable spanning-tree BPDU filter on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+        </PARAM>
+    <ACTION>
+        if test "${bpdufilt_sub_cmds}" = "enable";then&#xA;
+            python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_filter ${po_name} True&#xA;
+        elif test "${bpdufilt_sub_cmds}" = "disable";then&#xA;
+            python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_filter ${po_name} False&#xA;
+        fi&#xA;
+    </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="spanning-tree guard"
+        help = "Configure spanning tree guard on port-channel"
+        >
+        <PARAM
+            name="root"
+            help="Enables root guard on port-channel"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+            >
+        </PARAM>
+    <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_guard ${po_name} "ROOT"
+    </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="spanning-tree vlan"
+        help = "Configure spanning tree on port-channel for VLAN"
+        >
+        <PARAM
+            name="vlan-range"
+            help=""
+            ptype="STP_VLAN_ID"
+            >
+        </PARAM>
+
+            <PARAM
+                name="stp-if-vlan-subcmds"
+                help="spanning tree port-channel VLAN subcommands"
+                ptype="SUBCOMMAND" mode="switch"
+                >
+                <PARAM
+                    name="cost"
+                    help="Set the port level cost value for VLAN"
+                    ptype="SUBCOMMAND"
+                    mode="subcommand"
+                    >
+                    <PARAM
+                        name="value"
+                        help="Cost value"
+                        ptype="STP_COST"
+                        >
+                    </PARAM>
+
+                </PARAM>
+
+                <PARAM
+                    name="port-priority"
+                    help="Set the port level priority value for a VLAN"
+                    ptype="SUBCOMMAND"
+                    mode="subcommand"
+                    >
+                    <PARAM
+                        name="value"
+                        help="Priority value"
+                        ptype="STP_PORT_PRIORITY"
+                        >
+                    </PARAM>
+                </PARAM>
+            </PARAM>
+    <ACTION>
+       if test "${stp-if-vlan-subcmds}" = "cost";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_custom_stp_vlan_interfaces_interface_config_cost ${vlan-range} ${po_name} ${value}&#xA;
+        elif test "${stp-if-vlan-subcmds}" = "port-priority";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py  patch_custom_stp_vlan_interfaces_interface_config_port_priority ${vlan-range} ${po_name} ${value}&#xA;
+        fi&#xA;
+        builtin="clish_nop"
+    </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="no spanning-tree"
+        help = "Unconfigure spanning tree on port-channel"
+        >
+        <PARAM
+            name="stp-if-subcmds"
+            help="spannig tree port-channel subcommands"
+            ptype="SUBCOMMAND"
+            mode="switch"
+            >
+            <PARAM
+                name="bpdufilter"
+                help="if spanning-tree BPDU filter on the port-channel is disabled, global bpdufilter will be applied"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+            <PARAM
+                name="bpduguard"
+                help="Disabled bpdu guard on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="port-shutdown"
+                    help="disable port shutdown on bpdu guard violation"
+                    ptype="SUBCOMMAND"
+                    mode="subcommand"
+                    optional="true"
+                    >
+                </PARAM>
+            </PARAM>
+
+            <PARAM
+                name="cost"
+                help="Unset the port level cost value for a VLAN"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="enable"
+                help="Disables spanning-tree on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="link-type"
+                help="Unset link type of the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="portfast"
+                help="Disables portfast on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="port-priority"
+                help="Reset the port level priority on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="port"
+                help="Unset Spanning Tree port info"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+                <PARAM
+                    name="type"
+                    help="Unset port type of the port-channel"
+                    ptype="SUBCOMMAND"
+                    mode="subcommand"
+                    >
+                </PARAM>
+            </PARAM>
+            <PARAM
+                name="uplinkfast"
+                help="Disables uplink fast on the port-channel"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+        </PARAM>
+    <ACTION>
+       if test "${stp-if-subcmds}" = "bpduguard";then&#xA;
+            if test "${port-shutdown}" != "";then&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_bpdu_guard_port_shutdown ${po_name} False&#xA;
+            else&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_guard ${po_name} False&#xA;
+            fi&#xA;
+        elif test "${stp-if-subcmds}" = "uplinkfast";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_uplink_fast ${po_name} False&#xA;
+        elif test "${stp-if-subcmds}" = "bpdufilter";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_filter ${po_name}&#xA;
+        elif test "${stp-if-subcmds}" = "portfast";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_portfast ${po_name} False&#xA;
+        elif test "${stp-if-subcmds}" = "enable";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_spanning_tree_enable ${po_name} False&#xA;
+        elif test "${stp-if-subcmds}" = "cost";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_ext_stp_interfaces_interface_config_cost ${po_name}&#xA;
+        elif test "${stp-if-subcmds}" = "port-priority";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_ext_stp_interfaces_interface_config_port_priority ${po_name}&#xA;
+        elif test "${stp-if-subcmds}" = "link-type";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name}&#xA;
+        elif test "${stp-if-subcmds}" = "port";then&#xA;
+            if test "${type}" != "";then&#xA;
+                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_edge_port ${po_name} False&#xA;
+            fi&#xA;
+        fi&#xA;
+        builtin="clish_nop"
+    </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="no spanning-tree guard"
+        help = "Unconfigure spanning tree guard on port-channel"
+        >
+        <PARAM
+            name="root"
+            help="Disables root guard on port-channel"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+            >
+        </PARAM>
+    <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_guard ${po_name} "NONE"
+    </ACTION>
+    </COMMAND>
+
+    <COMMAND
+        name="no spanning-tree vlan"
+        help = "Unconfigure spanning tree on port-channel for given VLAN"
+        >
+        <PARAM
+            name="vlan-range"
+            help=""
+            ptype="STP_VLAN_ID"
+            >
+        </PARAM>
+
+        <PARAM
+            name="stp-if-vlan-subcmds"
+            help="spannig tree port-channel subcommands"
+            ptype="SUBCOMMAND"
+            mode="switch"
+            >
+            <PARAM
+                name="cost"
+                help="Unset the port level cost value for VLAN"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+
+            <PARAM
+                name="port-priority"
+                help="Unset the port level priority value for a VLAN"
+                ptype="SUBCOMMAND"
+                mode="subcommand"
+                >
+            </PARAM>
+        </PARAM>
+    <ACTION>
+       if test "${stp-if-vlan-subcmds}" = "cost";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_custom_stp_vlan_interfaces_interface_config_cost ${vlan-range} ${po_name}&#xA;
+        elif test "${stp-if-vlan-subcmds}" = "port-priority";then&#xA;
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py  delete_custom_stp_vlan_interfaces_interface_config_port_priority ${vlan-range} ${po_name}&#xA;
         fi&#xA;
         builtin="clish_nop"
     </ACTION>

--- a/src/CLI/clitree/cli-xml/stp.xml
+++ b/src/CLI/clitree/cli-xml/stp.xml
@@ -1067,166 +1067,152 @@ limitations under the License.
         name="spanning-tree"
         help = "Configure spanning tree on port-channel"
         >
-        <PARAM
-            name="stp-if-subcmds"
-            help="spannig tree port-channel subcommands"
-            ptype="SUBCOMMAND"
-            mode="switch"
-            >
-            <PARAM
-                name="bpduguard"
-                help="Enables bpdu guard on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="port-shutdown"
-                    help="Enable port shutdown on bpdu guard violation"
-                    ptype="SUBCOMMAND"
-                    mode="subcommand"
-                    optional="true"
-                    >
-                </PARAM>
-            </PARAM>
-            <PARAM
-                name="cost"
-                help="Set the port level cost"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="value"
-                    help="Port cost value"
-                    ptype="STP_COST"
-                    >
-                </PARAM>
-            </PARAM>
-            <PARAM
-                name="enable"
-                help="Enables spanning-tree on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-            <PARAM
-                name="link-type"
-                help="Set link type of the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="link-sub-cmds"
-                    help = "link type sub commands."
-                    ptype="SUBCOMMAND"
-                    mode="switch"
-                    >
-                    <PARAM
-                        name="auto"
-                        help = "link type is set based on the duplex setting of the port-channel."
-                        ptype="SUBCOMMAND"
-                        mode="subcommand"
-                        >
-                    </PARAM>
-                    <PARAM
-                        name="point-to-point"
-                        help = "link type of given port-channel is point-to-point."
-                        ptype="SUBCOMMAND"
-                        mode="subcommand"
-                        >
-                    </PARAM>
-                    <PARAM
-                        name="shared"
-                        help = "link type of given port-channel is shared."
-                        ptype="SUBCOMMAND"
-                        mode="subcommand"
-                        >
-                    </PARAM>
-                </PARAM>
-            </PARAM>
-            <PARAM
-                name="portfast"
-                help="Enables portfast on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
+    </COMMAND>
 
-            <PARAM
-                name="port-priority"
-                help="Set the port level priority"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="value"
-                    help="Port priority value"
-                    ptype="STP_PORT_PRIORITY"
-                    >
-                </PARAM>
-            </PARAM>
-
-            <PARAM
-                name="port"
-                help="Set Spanning tree port"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="type"
-                    help="Spanning Tree port type"
-                    ptype="SUBCOMMAND"
-                    mode="subcommand"
-                    >
-                    <PARAM
-                        name="edge"
-                        help="Edge port"
-                        ptype="SUBCOMMAND"
-                        mode="subcommand"
-                        >
-                    </PARAM>
-                </PARAM>
-            </PARAM>
-
-        <PARAM
-            name="uplinkfast"
-            help="Enables uplink fast on the port-channel"
-            ptype="SUBCOMMAND"
-            mode="subcommand"
-            >
-        </PARAM>
-    </PARAM>
-    <ACTION>
-        if test "${stp-if-subcmds}" = "bpduguard";then&#xA;
-            if test "${port-shutdown}" != "";then&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_bpdu_guard_port_shutdown ${po_name} True&#xA;
-            else&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_guard ${po_name} True&#xA;
-            fi&#xA;
-        elif test "${stp-if-subcmds}" = "portfast";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_portfast ${po_name} True&#xA;
-        elif test "${stp-if-subcmds}" = "uplinkfast";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_uplink_fast ${po_name} True&#xA;
-        elif test "${stp-if-subcmds}" = "enable";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_spanning_tree_enable ${po_name} True&#xA;
-        elif test "${stp-if-subcmds}" = "cost";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_cost ${po_name} ${value}&#xA;
-        elif test "${stp-if-subcmds}" = "port-priority";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_port_priority ${po_name} ${value}&#xA;
-        elif test "${stp-if-subcmds}" = "link-type";then&#xA;
-            if test "${link-sub-cmds}" = "auto";then&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name}&#xA;
-            elif test "${link-sub-cmds}" = "point-to-point";then&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name} "P2P"&#xA;
-            elif test "${link-sub-cmds}" = "shared";then&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name} "SHARED"&#xA;
-            fi&#xA;
-        elif test "${stp-if-subcmds}" = "port";then&#xA;
-            if test "${edge}" != "";then&#xA;
-            python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_edge_port ${po_name} True&#xA;
-            fi&#xA;
+    <COMMAND 
+        name="spanning-tree bpduguard" 
+        help="Enables bpdu guard on the port-channel" 
+        ptype="SUBCOMMAND" 
+        mode="subcommand">
+      <PARAM 
+        name="port-shutdown" 
+        help="Enable port shutdown on bpdu guard violation" 
+        ptype="SUBCOMMAND" 
+        mode="subcommand" 
+        optional="true"> 
+      </PARAM>
+      <ACTION>
+        if test "${port-shutdown}" != "";then&#xA;
+          python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_bpdu_guard_port_shutdown ${po_name} True&#xA;
+        else&#xA;
+          python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_guard ${po_name} True&#xA;
         fi&#xA;
         builtin="clish_nop"
-    </ACTION>
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree cost" 
+      help="Set the port level cost" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <PARAM 
+        name="value" 
+        help="Port cost value" 
+        ptype="STP_COST"> 
+      </PARAM>
+      <ACTION> 
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_cost ${po_name} ${value}&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree enable" 
+      help="Enables spanning-tree on the port-channel" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_spanning_tree_enable ${po_name} True&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree link-type" 
+      help="Set link type of the port-channel" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <PARAM 
+        name="link-sub-cmds" 
+        help="link type sub commands." 
+        ptype="SUBCOMMAND" 
+        mode="switch">
+        <PARAM 
+          name="auto" 
+          help="link type is set based on the duplex setting of the port-channel." 
+          ptype="SUBCOMMAND" 
+          mode="subcommand"> 
+        </PARAM>
+        <PARAM 
+          name="point-to-point" 
+          help="link type of given port-channel is point-to-point." 
+          ptype="SUBCOMMAND" 
+          mode="subcommand"> 
+        </PARAM>
+        <PARAM 
+          name="shared" 
+          help="link type of given port-channel is shared." 
+          ptype="SUBCOMMAND" 
+          mode="subcommand"> 
+        </PARAM>
+      </PARAM>
+      <ACTION>
+ if test "${link-sub-cmds}" = "auto";then&#xA;
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name}&#xA;
+ elif test "${link-sub-cmds}" = "point-to-point";then&#xA;
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name} "P2P"&#xA;
+ elif test "${link-sub-cmds}" = "shared";then&#xA;
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name} "SHARED"&#xA;
+ fi&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree portfast" 
+      help="Enables portfast on the port-channel" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <ACTION>
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_portfast ${po_name} True&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree port-priority" 
+      help="Set the port level priority" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <PARAM 
+        name="value" 
+        help="Port priority value" 
+        ptype="STP_PORT_PRIORITY"> 
+      </PARAM>
+      <ACTION>
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_port_priority ${po_name} ${value}&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree port" 
+      help="Set Spanning tree port" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <PARAM 
+        name="type" 
+        help="Spanning Tree port type" 
+        ptype="SUBCOMMAND" 
+        mode="subcommand">
+        <PARAM 
+          name="edge" 
+          help="Edge port" 
+          ptype="SUBCOMMAND" 
+          mode="subcommand"> 
+        </PARAM>
+      </PARAM>
+      <ACTION>
+ if test "${edge}" != "";then&#xA;
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_edge_port ${po_name} True&#xA;
+ fi&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND 
+      name="spanning-tree uplinkfast" 
+      help="Enables uplink fast on the port-channel" 
+      ptype="SUBCOMMAND" 
+      mode="subcommand">
+      <ACTION>
+ python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_uplink_fast ${po_name} True&#xA;
+      </ACTION>
     </COMMAND>
 
     <COMMAND

--- a/src/CLI/clitree/cli-xml/stp.xml
+++ b/src/CLI/clitree/cli-xml/stp.xml
@@ -1324,125 +1324,115 @@ limitations under the License.
         name="no spanning-tree"
         help = "Unconfigure spanning tree on port-channel"
         >
-        <PARAM
-            name="stp-if-subcmds"
-            help="spannig tree port-channel subcommands"
-            ptype="SUBCOMMAND"
-            mode="switch"
-            >
-            <PARAM
-                name="bpdufilter"
-                help="if spanning-tree BPDU filter on the port-channel is disabled, global bpdufilter will be applied"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-            <PARAM
-                name="bpduguard"
-                help="Disabled bpdu guard on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="port-shutdown"
-                    help="disable port shutdown on bpdu guard violation"
-                    ptype="SUBCOMMAND"
-                    mode="subcommand"
-                    optional="true"
-                    >
-                </PARAM>
-            </PARAM>
-
-            <PARAM
-                name="cost"
-                help="Unset the port level cost value for a VLAN"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-
-            <PARAM
-                name="enable"
-                help="Disables spanning-tree on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-
-            <PARAM
-                name="link-type"
-                help="Unset link type of the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-
-            <PARAM
-                name="portfast"
-                help="Disables portfast on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-
-            <PARAM
-                name="port-priority"
-                help="Reset the port level priority on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-
-            <PARAM
-                name="port"
-                help="Unset Spanning Tree port info"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-                <PARAM
-                    name="type"
-                    help="Unset port type of the port-channel"
-                    ptype="SUBCOMMAND"
-                    mode="subcommand"
-                    >
-                </PARAM>
-            </PARAM>
-            <PARAM
-                name="uplinkfast"
-                help="Disables uplink fast on the port-channel"
-                ptype="SUBCOMMAND"
-                mode="subcommand"
-                >
-            </PARAM>
-        </PARAM>
-    <ACTION>
-       if test "${stp-if-subcmds}" = "bpduguard";then&#xA;
-            if test "${port-shutdown}" != "";then&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_bpdu_guard_port_shutdown ${po_name} False&#xA;
-            else&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_guard ${po_name} False&#xA;
-            fi&#xA;
-        elif test "${stp-if-subcmds}" = "uplinkfast";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_uplink_fast ${po_name} False&#xA;
-        elif test "${stp-if-subcmds}" = "bpdufilter";then&#xA;
+    </COMMAND>
+    <COMMAND
+      name="no spanning-tree bpdufilter"
+      help="if spanning-tree BPDU filter on the port-channel is disabled, global bpdufilter will be applied"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
         python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_filter ${po_name}&#xA;
-        elif test "${stp-if-subcmds}" = "portfast";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_portfast ${po_name} False&#xA;
-        elif test "${stp-if-subcmds}" = "enable";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_spanning_tree_enable ${po_name} False&#xA;
-        elif test "${stp-if-subcmds}" = "cost";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_ext_stp_interfaces_interface_config_cost ${po_name}&#xA;
-        elif test "${stp-if-subcmds}" = "port-priority";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_ext_stp_interfaces_interface_config_port_priority ${po_name}&#xA;
-        elif test "${stp-if-subcmds}" = "link-type";then&#xA;
-        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name}&#xA;
-        elif test "${stp-if-subcmds}" = "port";then&#xA;
-            if test "${type}" != "";then&#xA;
-                python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_edge_port ${po_name} False&#xA;
-            fi&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree bpduguard"
+      help="Disabled bpdu guard on the port-channel"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <PARAM
+        name="port-shutdown"
+        help="disable port shutdown on bpdu guard violation"
+        ptype="SUBCOMMAND"
+        mode="subcommand"
+        optional="true">
+      </PARAM>
+      <ACTION>
+        if test "${port-shutdown}" != "";then&#xA;
+          python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_bpdu_guard_port_shutdown ${po_name} False&#xA;
+        else&#xA;
+          python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_bpdu_guard ${po_name} False&#xA;
         fi&#xA;
-        builtin="clish_nop"
-    </ACTION>
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree cost"
+      help="Unset the port level cost value for a VLAN"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_ext_stp_interfaces_interface_config_cost ${po_name}&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree enable"
+      help="Disables spanning-tree on the port-channel"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_spanning_tree_enable ${po_name} False&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree link-type"
+      help="Unset link type of the port-channel"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_stp_interfaces_interface_config_link_type ${po_name}&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree portfast"
+      help="Disables portfast on the port-channel"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_portfast ${po_name} False&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree port-priority"
+      help="Reset the port level priority on the port-channel"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py delete_openconfig_spanning_tree_ext_stp_interfaces_interface_config_port_priority ${po_name}&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree uplinkfast"
+      help="Disables uplink fast on the port-channel"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <ACTION>
+        python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_ext_stp_interfaces_interface_config_uplink_fast ${po_name} False&#xA;
+      </ACTION>
+    </COMMAND>
+
+    <COMMAND
+      name="no spanning-tree port"
+      help="Unset Spanning Tree port info"
+      ptype="SUBCOMMAND"
+      mode="subcommand">
+      <PARAM
+        name="type"
+        help="Unset port type of the port-channel"
+        ptype="SUBCOMMAND"
+        mode="subcommand"
+        optional="true">
+      </PARAM>
+      <ACTION>
+        if test "${type}" != "";then&#xA;
+          python $SONIC_CLI_ROOT/sonic-cli-stp.py patch_openconfig_spanning_tree_stp_interfaces_interface_config_edge_port ${po_name} False&#xA;
+        fi&#xA;
+      </ACTION>
     </COMMAND>
 
     <COMMAND

--- a/src/CLI/renderer/templates/show_stp.j2
+++ b/src/CLI/renderer/templates/show_stp.j2
@@ -188,20 +188,22 @@ RSTP (IEEE 802.1w) Port Parameters:
             {% if vars.update({'intf_desig_cost':intf['state']['designated-cost']}) %}{% endif %}
             {% if vars.update({'intf_desig_bridge':intf['state']['designated-bridge-address']}) %}{% endif %}
         {%endif%}
-               {% if stp_intf['config']['bpdu-filter'] == true %}
-                  {% if vars.update({'intf_bpdu_filter': "Y"}) %}{% endif %}
-               {%else %}
-                  {% if vars.update({'intf_bpdu_filter': "N"}) %}{% endif %}
-               {%endif %}
-               {% if stp_intf['config']['link-type'] == "P2P" %}
-                     {% if vars.update({'intf_p2pmac': "Y"}) %}{% endif %}
-               {%else %}
-                     {% if vars.update({'intf_p2pmac': "N"}) %}{% endif %}
-               {%endif %}
-               {% if stp_intf['config']['edge-port'] == "openconfig-spanning-tree-types:EDGE_ENABLE" %}
-                     {% if vars.update({'intf_edge': "Y"}) %}{% endif %}
-               {%else %}
-                     {% if vars.update({'intf_edge': "N"}) %}{% endif %}
+               {% if "state" is in stp_intf %}
+                 {% if "bpdu-filter" in stp_intf['state'] and stp_intf['state']['bpdu-filter'] == true %}
+                   {% if vars.update({'intf_bpdu_filter': "Y"}) %}{% endif %}
+                 {%else %}
+                   {% if vars.update({'intf_bpdu_filter': "N"}) %}{% endif %}
+                 {%endif %}
+                 {% if "link-type" in stp_intf['state'] and stp_intf['state']['link-type'] == "P2P" %}
+                   {% if vars.update({'intf_p2pmac': "Y"}) %}{% endif %}
+                 {%else %}
+                   {% if vars.update({'intf_p2pmac': "N"}) %}{% endif %}
+                 {%endif %}
+                 {% if "edge-port" in stp_intf['state'] and stp_intf['state']['edge-port'] == "openconfig-spanning-tree-types:EDGE_ENABLE" %}
+                   {% if vars.update({'intf_edge': "Y"}) %}{% endif %}
+                 {%else %}
+                   {% if vars.update({'intf_edge': "N"}) %}{% endif %}
+                 {%endif %}
                {%endif %}
 {{'%-16s'|format(vars.intf_name)}}{{'%-5s'|format(vars.intf_pri)}}{{'%-10s'|format(vars.intf_path_cost)}}{{'%-4s'|format(vars.intf_p2pmac)}}{{'%-5s'|format(vars.intf_edge)}}{{'%-7s'|format(vars.intf_bpdu_filter)}}{{'%-12s'|format(vars.intf_role)}}{{'%-11s'|format(vars.intf_state)}}{{'%-11s'|format(vars.intf_desig_cost)}}{{'%-17s'|format(vars.intf_desig_bridge)}}
         {%endif %}


### PR DESCRIPTION
- New command spanning-tree sub tree under port-channel interface to configure stp
- fix port-role/edge-port display issues in renderer
- look at state container for displaying vst information

~~~text
sonic(config)# interface PortChannel 4
sonic(conf-if-po4)#
  end            Exit to the exec Mode
  exit           Exit from current mode
  fallback       Configure LACP fallback
  ip             Interface Internet Protocol config commands
  ipv6           Interface Internet Protocol config commands
  link           Interface link
  mclag          Configure MCLAG interface
  min-links      Configure the minimum number of links in a PortChannel
  mtu            Configure MTU
  nat-zone       NAT Zone
  no             Negate a command or set its defaults
  shutdown       Disable the interface
  spanning-tree  Configure spanning tree on port-channel
  switchport     Configure switchport parameters
sonic(conf-if-po4)# spanning-tree
  bpdufilter     Spanning-tree BPDU filter on the port-channel
  bpduguard      Enables bpdu guard on the port-channel
  cost           Set the port level cost
  enable         Enables spanning-tree on the port-channel
  guard          Configure spanning tree guard on port-channel
  link-type      Set link type of the port-channel
  port           Set Spanning tree port
  port-priority  Set the port level priority
  portfast       Enables portfast on the port-channel
  uplinkfast     Enables uplink fast on the port-channel
  vlan           Configure spanning tree on port-channel for VLAN
sonic(conf-if-po4)# spanning-tree bpdufilter enable
Success
sonic(conf-if-po4)# spanning-tree bpdufilter disable
Success
sonic(conf-if-po4)# spanning-tree bpduguard port-shutdown
Success
sonic(conf-if-po4)# spanning-tree cost 100
Success
sonic(conf-if-po4)# spanning-tree enable
Success
sonic(conf-if-po4)# spanning-tree uplinkfast
Success
sonic(conf-if-po4)# spanning-tree portfast
Success
sonic(conf-if-po4)# spanning-tree port-priority 10
Success
sonic(conf-if-po4)# spanning-tree port type edge
Success
sonic(conf-if-po4)# spanning-tree link-type
auto           point-to-point shared
sonic(conf-if-po4)# spanning-tree link-type auto
Success
sonic(conf-if-po4)# spanning-tree guard root
Success

CONFIG-DB 

127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 1) "portfast"
 2) "true"
 3) "uplink_fast"
 4) "true"
 5) "link_type"
 6) "auto"
 7) "enabled"
 8) "true"
 9) "root_guard"
10) "true"
11) "bpdu_guard"
12) "false"
13) "bpdu_filter"
14) "global"
15) "bpdu_guard_do_disable"
16) "false"
17) "priority"
18) "10"
19) "edge_port"
20) "true"

SHOW COMMANDS

sonic(conf-if-Ethernet4)# do show spanning-tree
Spanning-tree Mode: RPVST

VLAN 4 - RSTP instance 0
------------------------------------------------------------------------------------------------------------

RSTP (IEEE 802.1w) Bridge Parameters:

Bridge            Bridge    Bridge    Bridge    tx
Identifier        MaxAge    Hello     FwdDly    Hold
hex               sec       sec       sec       cnt
800490b11cf4a3a7  20        2         15

RootBridge        RootPath  DesignatedBridge  Root        Max  Hel  Fwd
Identifier        Cost      Identifier        Port        Age  lo   Dly
hex                         hex                           sec  sec  sec
800490b11cf4a3a7  0         800490b11cf4a3a7  Root        20   2    15

RSTP (IEEE 802.1w) Port Parameters:
Port            Prio Path      P2P Edge BPDU   Role        State      Designa-   Designated
Num             rity Cost      Mac Port Filter                        ted cost   bridge
PortChannel4    128  4         Y   Y    Y                  DISABLED   0          0000000000000000
sonic(conf-if-Ethernet4)#

sonic(conf-if-Ethernet4)# do show spanning-tree vlan 4
Spanning-tree Mode: RPVST

VLAN 4 - RSTP instance 0
------------------------------------------------------------------------------------------------------------

RSTP (IEEE 802.1w) Bridge Parameters:

Bridge            Bridge    Bridge    Bridge    tx
Identifier        MaxAge    Hello     FwdDly    Hold
hex               sec       sec       sec       cnt
800490b11cf4a3a7  20        2         15

RootBridge        RootPath  DesignatedBridge  Root        Max  Hel  Fwd
Identifier        Cost      Identifier        Port        Age  lo   Dly
hex                         hex                           sec  sec  sec
800490b11cf4a3a7  0         800490b11cf4a3a7  Root        20   2    15

RSTP (IEEE 802.1w) Port Parameters:
Port            Prio Path      P2P Edge BPDU   Role        State      Designa-   Designated
Num             rity Cost      Mac Port Filter                        ted cost   bridge
PortChannel4    128  4         Y   Y    Y                  DISABLED   0          0000000000000000
sonic(conf-if-Ethernet4)#

sonic(conf-if-Ethernet4)# do show spanning-tree bpdu-guard
PortNum          Shutdown    Port shut
                 Configured  due to BPDU guard
sonic(conf-if-Ethernet4)#

DELETE COMMANDS

sonic(conf-if-po4)# spanning-tree cost 100
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
21) "path_cost"
22) "100"
127.0.0.1:6379[4]> 
sonic(conf-if-po4)# no spanning-tree cost
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 1) "portfast"
 2) "true"
 3) "uplink_fast"
 4) "true"
 5) "link_type"
 6) "auto"
 7) "enabled"
 8) "true"
 9) "root_guard"
10) "false"
11) "bpdu_guard"
12) "false"
13) "bpdu_filter"
14) "global"
15) "bpdu_guard_do_disable"
16) "false"
17) "priority"
18) "10"
19) "edge_port"
20) "true"
127.0.0.1:6379[4]> 
Success

sonic(conf-if-po4)# spanning-tree bpdufilter enable
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
13) "bpdu_filter"
14) "enable"

sonic(conf-if-po4)# no spanning-tree bpdufilter
Success
sonic(conf-if-po4)#

127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
13) "bpdu_filter"
14) "global"

sonic(conf-if-po4)# spanning-tree guard root
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 9) "root_guard"
10) "true"

sonic(conf-if-po4)# no spanning-tree guard root
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 9) "root_guard"
10) "false"

sonic(conf-if-po4)# spanning-tree link-type shared
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 5) "link_type"
 6) "shared"

sonic(conf-if-po4)# no spanning-tree link-type
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 5) "link_type"
 6) "auto"

sonic(conf-if-po4)# spanning-tree port type edge
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
19) "edge_port"
20) "true"

sonic(conf-if-po4)# no spanning-tree port type
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
19) "edge_port"
20) "false"

sonic(conf-if-po4)# spanning-tree port-priority 123
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
17) "priority"
18) "123"

sonic(conf-if-po4)# no spanning-tree port-priority
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 1) "portfast"
 2) "true"
 3) "uplink_fast"
 4) "true"
 5) "link_type"
 6) "auto"
 7) "enabled"
 8) "true"
 9) "root_guard"
10) "false"
11) "bpdu_guard"
12) "false"
13) "bpdu_filter"
14) "global"
15) "bpdu_guard_do_disable"
16) "true"
17) "edge_port"
18) "false"

sonic(conf-if-po4)# spanning-tree portfast
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 1) "portfast"
 2) "true"

sonic(conf-if-po4)# no spanning-tree portfast
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 1) "portfast"
 2) "false"

sonic(conf-if-po4)# spanning-tree uplinkfast
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 3) "uplink_fast"
 4) "true"

sonic(conf-if-po4)# no spanning-tree uplinkfast
Success
127.0.0.1:6379[4]> hgetall "STP_PORT|PortChannel4"
 3) "uplink_fast"
 4) "false"

~~~