### PR TITLE
Add null pointer check

### DIFF
--- a/src/cvl/cvl_semantics.go
+++ b/src/cvl/cvl_semantics.go
@@ -454,7 +454,7 @@ func (c *CVL) checkIfListNodeExists(dest, src *xmlquery.Node) *xmlquery.Node {
 	//CREATE/UPDATE/DELETE request for same table/key points to
 	//same yang list in request cache
 	yangList := entry[0].yangData
-	if (dest.Parent == yangList.Parent) {
+	if ((yangList != nil)  && (dest.Parent == yangList.Parent)) {
 		//Same parent means yang list already exists in destination tree
 		return yangList
 	}


### PR DESCRIPTION
Addressing this panic

~~~text
Jan 16 16:55:57.266450 sonic INFO mgmt-framework#supervisord: rest-server 2020/01/16 16:55:57 http: panic serving 127.0.0.1:51634: runtime error: invalid memory address or nil pointer dereference
Jan 16 16:55:57.266977 sonic INFO mgmt-framework#supervisord: rest-server goroutine 593 [running]:
Jan 16 16:55:57.268147 sonic INFO mgmt-framework#supervisord: rest-server net/http.(*conn).serve.func1(0xc0071f4820)
Jan 16 16:55:57.268912 sonic INFO mgmt-framework#supervisord: rest-server #011/usr/local/go/src/net/http/server.go:1746 +0x11e
Jan 16 16:55:57.269673 sonic INFO mgmt-framework#supervisord: rest-server panic(0x1c9c960, 0x3665cc0)
Jan 16 16:55:57.270542 sonic INFO mgmt-framework#supervisord: rest-server #011/usr/local/go/src/runtime/panic.go:513 +0x1e6
Jan 16 16:55:57.270902 sonic INFO mgmt-framework#supervisord: rest-server cvl.(*CVL).checkIfListNodeExists(0xc005a96fc0, 0xc005507180, 0xc005507f00, 0x0)
Jan 16 16:55:57.271924 sonic INFO mgmt-framework#supervisord: rest-server #011/sonic/src/sonic-mgmt-framework/src/cvl/cvl_semantics.go:457 +0x236
Jan 16 16:55:57.271924 sonic INFO mgmt-framework#supervisord: rest-server cvl.(*CVL).mergeYangData(0xc005a96fc0, 0xc005507180, 0xc005507f00, 0x0)
Jan 16 16:55:57.271924 sonic INFO mgmt-framework#supervisord: rest-server #011/sonic/src/sonic-mgmt-framework/src/cvl/cvl_semantics.go:500 +0x430
~~~