### PR TITLE
Set primary group for operator role to be `operator`

### DIFF
--- a/src/translib/transformer/host_acct_mgr.go
+++ b/src/translib/transformer/host_acct_mgr.go
@@ -17,7 +17,7 @@ func roleToGroup(role string) []string {
 		return []string{"admin", "sudo", "docker"}
 	
 	case "operator":
-		return []string{"docker"}
+		return []string{"operator", "docker"}
 	
 	default:
 		return []string{}


### PR DESCRIPTION
Prior to this change, the operator role was getting assigned to `docker`
as the primary group. This change fixes it to be inline with the `admin`
role, where the `admin` group is primary and supplementary groups are
added based on the role.