### PR TITLE
Handle requests for individual counters of an interface

### DIFF
--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -1703,7 +1703,7 @@ var DbToYang_intf_get_counters_xfmr SubTreeXfmrDbToYang = func(inParams XfmrPara
     targetUriPath, err := getYangPathFromUri(inParams.uri)
     log.Info("targetUriPath is ", targetUriPath)
 
-    if  targetUriPath != "/openconfig-interfaces:interfaces/interface/state/counters" {
+    if  (strings.Contains(targetUriPath, "/openconfig-interfaces:interfaces/interface/state/counters") == false) {
         log.Info("%s is redundant", targetUriPath)
         return err
     }


### PR DESCRIPTION
The xfmr function for interface counters is returning while handing requests for individual counters. Fix is to allow get requests of individual counters.
~~~text
get all
{
  "openconfig-interfaces:counters": {
    "in-broadcast-pkts": "43",
    "in-discards": "0",
    "in-errors": "0",
    "in-multicast-pkts": "62",
    "in-octets": "26764",
    "in-pkts": "105",
    "in-unicast-pkts": "0",
    "last-clear": "0",
    "out-broadcast-pkts": "38",
    "out-discards": "0",
    "out-errors": "0",
    "out-multicast-pkts": "65",
    "out-octets": "24679",
    "out-pkts": "103",
    "out-unicast-pkts": "0"
  }
}

curl -X GET "https://10.11.203.11/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet112/state/counters/in-broadcast-pkts" -H "accept: application/yang-data+json"
response:
{
  "openconfig-interfaces:in-broadcast-pkts": "32"
}

curl -X GET "https://10.11.203.11/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet112/state/counters/in-multicast-pkts" -H "accept: application/yang-data+json"
response:
{
  "openconfig-interfaces:in-multicast-pkts": "69"
}

curl -X GET "https://10.11.203.11/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet112/state/counters/in-octets" -H "accept: application/yang-data+json"
response:
{
  "openconfig-interfaces:in-octets": "32394"
}
~~~