### PR TITLE
Fixed 'interface' name in transformer code of show/clear ip/ipv6 arp/neighbors 

### DIFF
--- a/models/yang/sonic/sonic-neighbor.yang
+++ b/models/yang/sonic/sonic-neighbor.yang
@@ -45,7 +45,7 @@ module sonic-neighbor {
         input {
             leaf force {
                 type boolean;
-                description "Set it to True to delete PERMANENT/Static entries as well";
+                description "Set it to 'true' to delete PERMANENT/Static entries as well";
             }
 
             leaf family {
@@ -53,20 +53,15 @@ module sonic-neighbor {
                     enum IPv4;
                     enum IPv6;
                 }
-                description "Address family (IPv4/IPv6)";
+                description "Address family (IPv4/IPv6). Default: IPv4";
             }
 
             choice option {
-                leaf all {
-                    type boolean;
-                    description
-                        "Parameter for clearing all dynamic entries from ARP/NDP table";
-                }
-
                 leaf ip {
                     type inet:ip-prefix;
                     description
-                        "Parameter for deleting ARP/NDP entries related to the given IPv4/IPv6 address";
+                        "Parameter for deleting ARP/NDP entries related to the given IPv4/IPv6 address.
+                         Note: If both 'ip' and 'ifname' are not provided, all dynamic enties will be cleared from the ARP/NDP table.";
                 }
 
                 leaf ifname {
@@ -87,8 +82,9 @@ module sonic-neighbor {
                     description
                         "Interface name: Parameter for deleting all ARP  entries
                         related to the given inteface name Valid inputs are:
-                        Ethernet<port-number>/Vlan<Vlan ID>/PortChannel<port-channel ID>/Management<interface ID>.
-                        For example: Ethernet0, Vlan100, PortChannel10, eth0";
+                        Ethernet<port-number>/Vlan<Vlan ID>/PortChannel<port-channel ID>/eth<interface ID>.
+                        For example: Ethernet0, Vlan100, PortChannel10, eth0.
+                        Note: If both 'ip' and 'ifname' are not provided, all dynamic enties will be cleared from the ARP/NDP table.";
                 }
             }
         }
@@ -97,7 +93,7 @@ module sonic-neighbor {
             leaf response {
                 type string;
                 description
-                    "Success / failure in clearing up the entire ARP table";
+                    "Success / Failure in clearing up the entire ARP/NDP table";
             }
         }
     }
@@ -128,7 +124,7 @@ module sonic-neighbor {
                     }
                     description
                         "Valid inputs are:
-                        Ethernet<port-number>/Vlan<Vlan ID>/PortChannel<port-channel ID>/Management<interface ID>.
+                        Ethernet<port-number>/Vlan<Vlan ID>/PortChannel<port-channel ID>/eth<interface ID>.
                         For example: Ethernet0, Vlan100, PortChannel10, eth0";
                 }
 

--- a/src/CLI/actioner/sonic-cli-neighbors.py
+++ b/src/CLI/actioner/sonic-cli-neighbors.py
@@ -43,11 +43,11 @@ def get_keypath(func,args):
     elif func == 'rpc_sonic_clear_neighbors':
         keypath = cc.Path('/restconf/operations/sonic-neighbor:clear-neighbors')
         if (len (args) == 2):
-            body = {"sonic-neighbor:input":{"family": args[0], "force": args[1], "all": "true", "ip": "", "interface": ""}}
+            body = {"sonic-neighbor:input":{"family": args[0], "force": args[1], "ip": "", "ifname": ""}}
         elif (len (args) == 3):
-            body = {"sonic-neighbor:input":{"family": args[0], "force": args[1], "all": "false", "ip": args[2], "interface": ""}}
+            body = {"sonic-neighbor:input":{"family": args[0], "force": args[1], "ip": args[2], "ifname": ""}}
         elif (len (args) == 4):
-            body = {"sonic-neighbor:input":{"family": args[0], "force": args[1], "all": "false", "ip": "", "interface": args[3]}}
+            body = {"sonic-neighbor:input":{"family": args[0], "force": args[1], "ip": "", "ifname": args[3]}}
 
     return keypath, body
 
@@ -216,7 +216,7 @@ def run(func, args):
         elif 'sonic-neighbor:output' in response.keys():
             status = response['sonic-neighbor:output']
             status = status['response']
-            if (status != ""):
+            if (status != "Success"):
                 print status
             return
         else:

--- a/src/translib/transformer/xfmr_neighbors.go
+++ b/src/translib/transformer/xfmr_neighbors.go
@@ -502,13 +502,11 @@ var rpc_clear_neighbors RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) (
     if input, ok := mapData["ifname"]; ok {
         input_str := fmt.Sprintf("%v", input)
         intf = input_str
-        log.Info("input_str: ", input_str," input: ", input, " len (input_str): ", len(input_str))
     }
 
     if input, ok := mapData["ip"]; ok {
         input_str := fmt.Sprintf("%v", input)
         ip = input_str
-        log.Info("input_str: ", input_str," input: ", input, " len (input_str): ", len(input_str))
     }
 
     if len(intf) > 0 {

--- a/src/translib/transformer/xfmr_neighbors.go
+++ b/src/translib/transformer/xfmr_neighbors.go
@@ -28,6 +28,7 @@ import (
     "fmt"
     "os/exec"
     "bufio"
+    "strconv"
 )
 
 func init () {
@@ -314,12 +315,42 @@ var DbToYang_neigh_tbl_get_all_ipv6_xfmr SubTreeXfmrDbToYang = func (inParams Xf
     return err
 }
 
-func clear_arp_all(fam_switch string, force string) string {
+func clear_arp_all(fam_switch string, force bool) string {
     var err error
+    var isPerm bool = false
 
-    if (force == "true") {
+    /* First check if we have any permanent entry */
+    cmd := exec.Command("ip", fam_switch, "neigh", "show", "all")
+    cmd.Dir = "/bin"
+
+    out, err := cmd.StdoutPipe()
+    if err != nil {
+        log.Info("Can't get stdout pipe: ", err)
+        return err.Error()
+    }
+
+    err = cmd.Start()
+    if err != nil {
+        log.Info("cmd.Start() failed with: ", err)
+        return err.Error()
+    }
+
+    in := bufio.NewScanner(out)
+    for in.Scan() {
+        line := in.Text()
+
+        if strings.Contains(line, "PERMANENT") && force == false {
+            isPerm = true
+            break
+        }
+    }
+
+    /* Now flush all entries */
+    if (force == true) {
+        log.Info("Executing: ip ", fam_switch, " -s ", "-s ", "neigh ", "flush ", "all ", "nud ", "all")
         _, err = exec.Command("ip", fam_switch, "-s", "-s", "neigh", "flush", "all", "nud", "all").Output()
     } else {
+        log.Info("Executing: ip ", fam_switch, " -s ", "-s ", "neigh ", "flush ", "all")
         _, err = exec.Command("ip", fam_switch, "-s", "-s", "neigh", "flush", "all").Output()
     }
 
@@ -327,17 +358,19 @@ func clear_arp_all(fam_switch string, force string) string {
         log.Info(err)
         return err.Error()
     }
-    return ""
+    if isPerm {
+        return "Permanent entry found, use 'force' to delete permanent entries"
+    } else {
+        return "Success"
+    }
 }
 
-func clear_arp_ip(ip string, fam_switch string, force string) string {
+func clear_arp_ip(ip string, fam_switch string, force bool) string {
     var intf string
 
     //get interface first associated with this ip
-    log.Info("---A:", ip, fam_switch, force, ip)
     out, err := exec.Command("ip", fam_switch, "neigh", "show", ip).Output()
     line := string(out)
-    log.Info("---line:", line)
 
     if err != nil {
         log.Info(err)
@@ -348,27 +381,27 @@ func clear_arp_ip(ip string, fam_switch string, force string) string {
         list := strings.Fields(line)
         intf = list[2]
     } else {
-        str := "Neighbor " + ip + " not found"
+        str := "Error: Neighbor " + ip + " not found"
         return str
     }
 
-    log.Info("---1:", ip, fam_switch, force)
-    if strings.Contains(line, "PERMANENT") && force == "false" {
-        return ""
+    if strings.Contains(line, "PERMANENT") && force == false {
+        return "Permanent entry found, use 'force' to delete permanent entries"
     }
 
+    log.Info("Executing: ip ", fam_switch, " neigh ", "del ", ip, " dev ", intf)
     out, err = exec.Command("ip", fam_switch, "neigh", "del", ip, "dev", intf).Output()
-    log.Info("---2:", ip, fam_switch, force, ip, intf)
     if err != nil {
         log.Info(err)
         return err.Error()
     }
 
-    return ""
+    return "Success"
 }
 
-func clear_arp_intf(intf string, fam_switch string, force string) string {
+func clear_arp_intf(intf string, fam_switch string, force bool) string {
     var isValidIntf bool = false
+    var isPerm bool = false
 
     cmd := exec.Command("ip", fam_switch, "neigh", "show", "dev", intf)
     cmd.Dir = "/bin"
@@ -385,7 +418,6 @@ func clear_arp_intf(intf string, fam_switch string, force string) string {
         return err.Error()
     }
 
-    // read command's stdout line by line
     in := bufio.NewScanner(out)
     for in.Scan() {
         line := in.Text()
@@ -395,14 +427,15 @@ func clear_arp_intf(intf string, fam_switch string, force string) string {
             return line
         }
 
-        if strings.Contains(line, "PERMANENT") && force == "false" {
-            log.Info("Skipping permenant entry: ", line)
+        if strings.Contains(line, "PERMANENT") && force == false {
             isValidIntf = true
+            isPerm = true
             continue
         }
 
         list := strings.Fields(line)
         ip := list[0]
+        log.Info("Executing: ip ", fam_switch, " neigh ", "del ", ip, " dev ", intf)
         _, e := exec.Command("ip", fam_switch, "neigh", "del", ip, "dev", intf).Output()
         if e != nil {
             log.Info(e)
@@ -411,10 +444,12 @@ func clear_arp_intf(intf string, fam_switch string, force string) string {
         isValidIntf = true
     }
 
-    if isValidIntf {
-        return ""
+    if isValidIntf == true && isPerm == false {
+        return "Success"
+    } else if isPerm == true {
+        return "Permanent entry found, use 'force' to delete permanent entries"
     } else {
-        return "Interface " + intf + " not found"
+        return "Error: Interface " + intf + " not found"
     }
 }
 
@@ -422,7 +457,10 @@ var rpc_clear_neighbors RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) (
     log.Info("In rpc_clear_neighbors")
     var err error
     var status string
-    var fam_switch string
+    var fam_switch string = "-4"
+    var force bool = false
+    var intf string = ""
+    var ip string = ""
 
     var mapData map[string]interface{}
     err = json.Unmarshal(body, &mapData)
@@ -437,39 +475,47 @@ var rpc_clear_neighbors RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) (
         } `json:"sonic-neighbor:output"`
     }
 
-    input, _ := mapData["sonic-neighbor:input"]
-    mapData = input.(map[string]interface{})
-
-    input = mapData["family"]
-    input_str := fmt.Sprintf("%v", input)
-    family := input_str
-    if family == "IPv4" {
-        fam_switch = "-4"
+    if input, ok := mapData["sonic-neighbor:input"]; ok {
+        mapData = input.(map[string]interface{})
     } else {
-        fam_switch = "-6"
+        result.Output.Status = "Invalid input"
+        return json.Marshal(&result)
     }
 
-    input = mapData["force"]
-    input_str = fmt.Sprintf("%v", input)
-    force := input_str
+    if input, ok := mapData["family"]; ok {
+        input_str := fmt.Sprintf("%v", input)
+        family := input_str
+        if family == "IPv6" {
+            fam_switch = "-6"
+        }
+    }
 
-    input = mapData["interface"]
-    input_str = fmt.Sprintf("%v", input)
-    intf := input_str
+    if input, ok := mapData["force"]; ok {
+        input_str := fmt.Sprintf("%v", input)
+        force, err = strconv.ParseBool(input_str)
+        if (err != nil) {
+            result.Output.Status = "Invalid input"
+            return json.Marshal(&result)
+        }
+    }
 
-    input = mapData["ip"]
-    input_str = fmt.Sprintf("%v", input)
-    ip := input_str
+    if input, ok := mapData["ifname"]; ok {
+        input_str := fmt.Sprintf("%v", input)
+        intf = input_str
+        log.Info("input_str: ", input_str," input: ", input, " len (input_str): ", len(input_str))
+    }
 
-    input = mapData["all"]
-    input_str = fmt.Sprintf("%v", input)
-    all := input_str
+    if input, ok := mapData["ip"]; ok {
+        input_str := fmt.Sprintf("%v", input)
+        ip = input_str
+        log.Info("input_str: ", input_str," input: ", input, " len (input_str): ", len(input_str))
+    }
 
-    if intf != "" {
+    if len(intf) > 0 {
         status = clear_arp_intf(intf, fam_switch, force)
-    } else if ip != "" {
+    } else if len(ip) > 0 {
         status = clear_arp_ip(ip, fam_switch, force)
-    } else if all != "False" || all != "false" {
+    } else if len(intf) <= 0 && len(ip) <= 0 {
         status = clear_arp_all(fam_switch, force)
     }
 

--- a/src/translib/transformer/xfmr_neighbors.go
+++ b/src/translib/transformer/xfmr_neighbors.go
@@ -485,7 +485,7 @@ var rpc_clear_neighbors RpcCallpoint = func(body []byte, dbs [db.MaxDB]*db.DB) (
     if input, ok := mapData["family"]; ok {
         input_str := fmt.Sprintf("%v", input)
         family := input_str
-        if family == "IPv6" {
+        if strings.EqualFold(family, "IPv6") || family == "1" {
             fam_switch = "-6"
         }
     }


### PR DESCRIPTION
- Fixed 'interface' name in the transformer code. 
- Removed 'all' field from sonic-neighbor.yang; wasn't required.
- Fixed REST API issues for show/clear ip/ipv6 arp/neighbors. 