### PR TITLE
Fix show vlan pipe options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ $(GO) install -v -gcflags "-N -l" $(BUILD_GOPATH)/src/github.com/go-redis/redis
 cli: 
 	$(MAKE) -C src/CLI
 
+clish:
+	SONIC_CLI_ROOT=$(BUILD_DIR) $(MAKE) -C src/CLI/klish
+
 clitree:
 	 TGT_DIR=$(BUILD_DIR)/cli $(MAKE) -C src/CLI/clitree
 

--- a/src/CLI/actioner/cli_client.py
+++ b/src/CLI/actioner/cli_client.py
@@ -195,3 +195,5 @@ def add_error_prefix(err_msg):
         return '%Error: ' + err_msg
     return err_msg
 
+def set_command(cmd):
+    os.environ['USER_COMMAND'] = cmd

--- a/src/CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c
+++ b/src/CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c
@@ -8,11 +8,35 @@ void pyobj_init() {
     Py_Initialize();
 }
 
+static int pyobj_set_user_cmd(const char *cmd) {
+    PyObject *module, *value;
+
+    module = PyImport_ImportModule("cli_client");
+    if (module == NULL) {
+        PyErr_Print();
+        return -1;
+    }
+
+    value = PyObject_CallMethod(module, "set_command", "(s)", cmd);
+    if (value == NULL) {
+        syslog(LOG_WARNING, "%s failed calling set_command", __FUNCTION__);
+        PyErr_Print();
+        return 1;
+    }
+
+    Py_DECREF(module);
+    Py_DECREF(value);
+
+    return 0;
+}
+
 int call_pyobj(char *cmd, const char *arg) {
     char *token[10];
     char buf[256]; 
 
+    pyobj_set_user_cmd(cmd);
     syslog(LOG_DEBUG, "clish_pyobj: cmd=%s", cmd);
+
     strcpy(buf, arg);
     char *p = strtok(buf, " ");
     size_t idx = 0;

--- a/src/CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c
+++ b/src/CLI/klish/patches/klish-2.1.4/plugins/clish/call_pyobj.c
@@ -77,6 +77,5 @@ int call_pyobj(char *cmd, const char *arg) {
 CLISH_PLUGIN_SYM(clish_pyobj)
 {
     char *cmd = clish_shell__get_full_line(clish_context);
-    call_pyobj(cmd, script);
-    return 0;
+    return call_pyobj(cmd, script);
 }

--- a/src/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.c
+++ b/src/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.c
@@ -160,6 +160,7 @@ int rest_cl(char *cmd, const char *buff)
   strncpy(arg, buff, sizeof(arg)-1);
   arg[sizeof(arg)-1] = '\0';
 
+  setenv("USER_COMMAND", cmd, 1); 
   syslog(LOG_DEBUG, "clish_restcl: cmd=%s", cmd);
 
   if (curl == NULL) {

--- a/src/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.c
+++ b/src/CLI/klish/patches/klish-2.1.4/plugins/clish/rest_cl.c
@@ -249,8 +249,7 @@ int rest_cl(char *cmd, const char *buff)
 CLISH_PLUGIN_SYM(clish_restcl)
 {
     char *cmd = clish_shell__get_full_line(clish_context);
-    rest_cl(cmd, script);
-    return 0;
+    return rest_cl(cmd, script);
 }
 
 

--- a/src/CLI/renderer/scripts/render_cli.py
+++ b/src/CLI/renderer/scripts/render_cli.py
@@ -145,6 +145,10 @@ def show_cli_output(template_file, response):
 
     j2_env.globals.update(datetimeformat=datetimeformat)
 
+    full_cmd = os.getenv('USER_COMMAND', None)
+    if full_cmd is not None:
+        pipestr().write(full_cmd.split())
+
     if response:
         t_str = (j2_env.get_template(template_file).render(json_output=response))
         write(t_str)


### PR DESCRIPTION
Issues:
1) "show vlan" doesnt show any output if it is the first show command executed
2) "show vlan" shows data if executed after another show command but pipe options for show vlan doesnt work.

RCA:
For the pipe options to work, pipestr().write() needs to be called in the python actioner script. Currently, it is called in the main function of each script.
With the move to embedded python approach, we call "run" function directly. Hence the pipestr().write() was getting skipped.
"show vlan" doesnt work the first time because the rendering code expects the pipestr.txt (created through the pipestr().write() call) to exist. Since the file doesn't exist, an exception was getting thrown.
The root cause for the pipe options not working is also the same.

Fix: From CLISH set an environment variable USER_COMMAND that holds the full command executed by the user. The rendering infra will use this to create the pipestr.txt through the pipestr().write() call.


~~~text
sonic# show vlan
Q: A - Access (Untagged), T - Tagged
NUM        Status      Q Ports
1          Inactive   
2          Inactive   
3          Inactive   
4          Inactive   
5          Inactive   
6          Inactive   
7          Inactive   
8          Inactive   
9          Inactive   
10         Inactive   
11         Inactive   
12         Inactive   
13         Inactive   
14         Inactive   
15         Inactive   
16         Inactive   
17         Inactive   
18         Inactive   
19         Inactive   
20         Inactive   
21         Inactive   
22         Inactive   
23         Inactive   
--more--
24         Inactive   
25         Inactive   
26         Inactive   
27         Inactive   
28         Inactive   
29         Inactive   
30         Inactive
	
sonic#   
~~~

With **" | no-more"** option
~~~text
sonic# show vlan | no-more 
Q: A - Access (Untagged), T - Tagged
NUM        Status      Q Ports
1          Inactive   
2          Inactive   
3          Inactive   
4          Inactive   
5          Inactive   
6          Inactive   
7          Inactive   
8          Inactive   
9          Inactive   
10         Inactive   
11         Inactive   
12         Inactive   
13         Inactive   
14         Inactive   
15         Inactive   
16         Inactive   
17         Inactive   
18         Inactive   
19         Inactive   
20         Inactive   
21         Inactive   
22         Inactive   
23         Inactive   
24         Inactive   
25         Inactive   
26         Inactive   
27         Inactive   
28         Inactive   
29         Inactive   
30         Inactive 
	
sonic#
~~~