### PR TITLE
Modify port priority range in sonic yang to be in sync with OC yang

### DIFF
--- a/models/yang/sonic/sonic-spanning-tree.yang
+++ b/models/yang/sonic/sonic-spanning-tree.yang
@@ -83,7 +83,7 @@ module sonic-spanning-tree {
 
         leaf priority {
             type uint8 {
-                range "0..240" {
+                range "1..240" {
                     error-message "Invalid Port Priority value.";
                 }
             }

--- a/src/CLI/clitree/cli-xml/stp.xml
+++ b/src/CLI/clitree/cli-xml/stp.xml
@@ -70,7 +70,7 @@ limitations under the License.
       <PTYPE
            name="STP_PORT_PRIORITY"
            method="integer"
-           pattern="0..240"
+           pattern="1..240"
            help=""
            />
        <!--=======================================================-->


### PR DESCRIPTION
The range for spanning tree port priority was 1-240 in oc yang. 
~~~text
  typedef stp-port-priority-type {
    type uint8 {
      range 1..240;
    }
~~~

Changed sonic yang to be in sync. Now, 0 is not a valid value.

~~~text
sonic(conf-if-po4)# spanning-tree port-priority
    Port priority value (1..240)
sonic(conf-if-po4)# spanning-tree port-priority 240
Success
sonic(conf-if-po4)# spanning-tree port-priority 1
Success
sonic(conf-if-po4)# spanning-tree port-priority 0
Syntax error: Illegal parameter

~~~

