### PR TITLE
1. Display static LAG members and LACP Fallback Validation

### DIFF
--- a/src/CLI/actioner/sonic-cli-interface-port-channel.py
+++ b/src/CLI/actioner/sonic-cli-interface-port-channel.py
@@ -37,6 +37,10 @@ def invoke_api(func, args=[]):
         path = cc.Path('/restconf/data/sonic-portchannel:sonic-portchannel/LAG_TABLE/LAG_TABLE_LIST={lagname}', lagname=args[0])
         return api.get(path)
 
+    if func == 'get_sonic_portchannel_sonic_portchannel_lag_member_table':
+        path = cc.Path('/restconf/data/sonic-portchannel:sonic-portchannel/LAG_MEMBER_TABLE')
+        return api.get(path)
+        
     if func == 'get_sonic_portchannel_sonic_portchannel_portchannel':
         path = cc.Path('/restconf/data/sonic-portchannel:sonic-portchannel/PORTCHANNEL')
         return api.get(path)
@@ -101,6 +105,14 @@ def get_lag_data():
                         output['sonic-portchannel:PORTCHANNEL']['PORTCHANNEL_LIST'] = api_resp['sonic-portchannel:PORTCHANNEL_LIST']
                 else:
                     output.update( api_resp )
+
+        # GET LAG Members
+        resp2 = invoke_api('get_sonic_portchannel_sonic_portchannel_lag_member_table', args)
+        if resp2.ok():
+            if resp2.content is not None:
+                # Get Command Output
+                api_resp2 = resp2.content
+                output.update( api_resp2 )
 
     except Exception as e:
         print("Exception when calling get_lag_data : %s\n" %(e))

--- a/src/CLI/renderer/templates/show_interface_portchannel.j2
+++ b/src/CLI/renderer/templates/show_interface_portchannel.j2
@@ -1,6 +1,5 @@
 {% set mode, minlinks, fallback = "LACP", "1", "Disabled" %}
 
-
 {% if json_output['portchannel']['sonic-portchannel:LAG_TABLE'] and json_output['portchannel']['sonic-portchannel:LAG_TABLE']['LAG_TABLE_LIST'] %}
 {% for po_intf in json_output['portchannel']['sonic-portchannel:LAG_TABLE']['LAG_TABLE_LIST'] %}
 
@@ -46,6 +45,15 @@ MTU {{po_intf['mtu']}}
 
 {% if 'state' in intf %}
 LACP mode {{intf['state']['lacp-mode']}} interval {{intf['state']['interval']}} priority {{intf['state']['system-priority']}} address {{intf['state']['system-id-mac']}}
+
+{% else %}
+
+{% for lag_mem in json_output['portchannel']['sonic-portchannel:LAG_MEMBER_TABLE']['LAG_MEMBER_TABLE_LIST'] %}
+{% if lag_mem['name'] == po_intf['lagname'] %}
+Members in this channel: {{ lag_mem['ifname'] }}
+{% endif %}
+{% endfor %}
+
 {% endif %}
 
 
@@ -63,6 +71,13 @@ LACP Partner port {{mem['state']['partner-port-num']}}  address {{mem['state']['
 {% endfor %}
 {% endif %}
 
+{% endif %}
+
+{% endfor %}
+
+{% endif %}
+
+
 {% if po_intf['counters'] %}
 {%set counters = po_intf['counters']['openconfig-interfaces:counters'] %}
 Last clearing of "show interface" counters: {{ datetimeformat(counters['last-clear']) }}
@@ -77,15 +92,7 @@ Output statistics:
 {{counters['out-errors']}} error, {{counters['out-discards']}} discarded
 {% endif %}
 
-
-{% endif %}
-
-
+{{'\r\n\r\n'}}
 {% endfor %}
 {% endif %}
-
-
-{% endfor %}
-{% endif %}
-
 


### PR DESCRIPTION
CLI UT:

![fallback_validation2](https://user-images.githubusercontent.com/24555377/72933779-42a6ef00-3d17-11ea-9a67-31025431f90d.PNG)


![show_intf_portchannel_id_output](https://user-images.githubusercontent.com/24555377/72930509-f0fb6600-3d10-11ea-8be0-d350748c62bd.PNG)
![show_intf_portchannel_output](https://user-images.githubusercontent.com/24555377/72930511-f0fb6600-3d10-11ea-9353-a2624f4be5ca.PNG)
