### PR TITLE
Changing txcache type to sync map to support go routines

### DIFF
--- a/src/translib/common_app.go
+++ b/src/translib/common_app.go
@@ -194,7 +194,7 @@ func (app *CommonApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
     var payload []byte
     var resPayload []byte
     log.Info("processGet:path =", app.pathInfo.Path)
-    txCache := sync.Map{}
+    txCache := new(sync.Map)
 
     for {
 	    // Keep a copy of the ygotRoot and let Transformer use this copy of ygotRoot
@@ -304,7 +304,7 @@ func (app *CommonApp) translateCRUDCommon(d *db.DB, opcode int) ([]db.WatchKeys,
 	var err error
 	var keys []db.WatchKeys
 	var tblsToWatch []*db.TableSpec
-	txCache := sync.Map{}
+	txCache := new(sync.Map)
 	log.Info("translateCRUDCommon:path =", app.pathInfo.Path)
 
 	// translate yang to db

--- a/src/translib/common_app.go
+++ b/src/translib/common_app.go
@@ -31,6 +31,7 @@ import (
 	"translib/tlerr"
 	"translib/transformer"
 	"cvl"
+	"sync"
 )
 
 var ()
@@ -193,7 +194,7 @@ func (app *CommonApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error) {
     var payload []byte
     var resPayload []byte
     log.Info("processGet:path =", app.pathInfo.Path)
-    txCache:= make(map[string]interface{})
+    txCache := sync.Map{}
 
     for {
 	    // Keep a copy of the ygotRoot and let Transformer use this copy of ygotRoot
@@ -303,7 +304,7 @@ func (app *CommonApp) translateCRUDCommon(d *db.DB, opcode int) ([]db.WatchKeys,
 	var err error
 	var keys []db.WatchKeys
 	var tblsToWatch []*db.TableSpec
-	txCache:= make(map[string]interface{})
+	txCache := sync.Map{}
 	log.Info("translateCRUDCommon:path =", app.pathInfo.Path)
 
 	// translate yang to db

--- a/src/translib/transformer/xfmr_interface.go
+++ b/src/translib/transformer/xfmr_interface.go
@@ -38,7 +38,7 @@ type XfmrParams struct {
 	dbDataMap *map[db.DBNum]map[string]map[string]db.Value
 	subOpDataMap map[int]*RedisDbMap // used to add an in-flight data with a sub-op
 	param interface{}
-	txCache sync.Map
+	txCache *sync.Map
 	skipOrdTblChk *bool
 }
 

--- a/src/translib/transformer/xfmr_interface.go
+++ b/src/translib/transformer/xfmr_interface.go
@@ -21,6 +21,7 @@ package transformer
 import (
 	"github.com/openconfig/ygot/ygot"
 	"translib/db"
+	"sync"
 )
 
 type RedisDbMap = map[db.DBNum]map[string]map[string]db.Value
@@ -37,7 +38,7 @@ type XfmrParams struct {
 	dbDataMap *map[db.DBNum]map[string]map[string]db.Value
 	subOpDataMap map[int]*RedisDbMap // used to add an in-flight data with a sub-op
 	param interface{}
-	txCache map[string]interface{}
+	txCache sync.Map
 	skipOrdTblChk *bool
 }
 

--- a/src/translib/transformer/xfmr_system.go
+++ b/src/translib/transformer/xfmr_system.go
@@ -326,11 +326,11 @@ var YangToDb_sys_aaa_auth_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
     }
     var status bool
     var err_str string
-    if _ , _ok := inParams.txCache[userName];!_ok {
-	    inParams.txCache[userName] = userName
+    if _ , _ok := inParams.txCache.load(userName);!_ok {
+	    inParams.txCache.store(userName, userName)
     } else {
-	    if _,present := inParams.txCache["tx_err"]; present {
-	            return nil, fmt.Errorf("%s",inParams.txCache["tx_err"])
+	    if val,present := inParams.txCache.load("tx_err"); present {
+	            return nil, fmt.Errorf("%s",val)
 	        }
 	    return nil,nil
     }
@@ -345,9 +345,9 @@ var YangToDb_sys_aaa_auth_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
         }
     }
 	if (!status) {
-		if _,present := inParams.txCache["tx_err"]; !present {
+		if _,present := inParams.txCache.load("tx_err"); !present {
 		    log.Info("Error in operation:",err_str)
-	            inParams.txCache["tx_err"] =err_str 
+	            inParams.txCache.store("tx_err",err_str) 
 	            return nil, fmt.Errorf("%s",err_str)
 	        }
 	} else {

--- a/src/translib/transformer/xfmr_system.go
+++ b/src/translib/transformer/xfmr_system.go
@@ -319,8 +319,6 @@ var YangToDb_sys_aaa_auth_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
     usersObj := sysObj.Aaa.Authentication.Users
     userName := pathInfo.Var("username")
     log.Info("username:",userName)
-
-
     if len(userName) == 0 {
 	return nil, nil
     }
@@ -348,7 +346,7 @@ var YangToDb_sys_aaa_auth_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
 		if _,present := inParams.txCache.Load("tx_err"); !present {
 		    log.Info("Error in operation:",err_str)
 	            inParams.txCache.Store("tx_err",err_str) 
-	            return nil, fmt.Errorf("%s",err_str)
+	            return nil, fmt.Errorf("%s", err_str)
 	        }
 	} else {
 		return nil, nil

--- a/src/translib/transformer/xlate_utils.go
+++ b/src/translib/transformer/xlate_utils.go
@@ -30,6 +30,7 @@ import (
     "github.com/openconfig/gnmi/proto/gnmi"
     "github.com/openconfig/ygot/ygot"
     log "github.com/golang/glog"
+    "sync"
 )
 
 /* Create db key from data xpath(request) */
@@ -409,7 +410,7 @@ func formXfmrInputRequest(d *db.DB, dbs [db.MaxDB]*db.DB, cdb db.DBNum, ygRoot *
 	inParams.dbDataMap = dbDataMap
 	inParams.subOpDataMap = subOpDataMap
 	inParams.param = param // generic param
-	inParams.txCache = txCache.(map[string]interface{})
+	inParams.txCache = txCache.(sync.Map)
 	inParams.skipOrdTblChk = new(bool)
 
 	return inParams

--- a/src/translib/transformer/xlate_utils.go
+++ b/src/translib/transformer/xlate_utils.go
@@ -410,7 +410,7 @@ func formXfmrInputRequest(d *db.DB, dbs [db.MaxDB]*db.DB, cdb db.DBNum, ygRoot *
 	inParams.dbDataMap = dbDataMap
 	inParams.subOpDataMap = subOpDataMap
 	inParams.param = param // generic param
-	inParams.txCache = txCache.(sync.Map)
+	inParams.txCache = txCache.(*sync.Map)
 	inParams.skipOrdTblChk = new(bool)
 
 	return inParams


### PR DESCRIPTION
The type of txcache in xfmr_params struct is changed to sync map from regular map to prevent race conditions while used in go routines. This PR contains the necessary changes.