### PR TITLE
Fix auth issues between CLI and non-CLI rest ports

### DIFF
--- a/src/rest/main/main.go
+++ b/src/rest/main/main.go
@@ -45,8 +45,7 @@ var (
 	keyFile   string // Server private key file path
 	caFile    string // Client CA certificate file path
 	cliCAFile string // CLI client CA certificate file path
-	jwtValInt uint64 // JWT Valid Interval
-	jwtRefInt uint64 // JWT Refresh seconds before expiry
+	clientAuth = server.UserAuth{"password": false, "cert": false, "jwt": false}
 )
 
 func init() {
@@ -56,9 +55,7 @@ func init() {
 	flag.StringVar(&keyFile, "key", "", "Server private key file path")
 	flag.StringVar(&caFile, "cacert", "", "CA certificate for client certificate validation")
 	flag.StringVar(&cliCAFile, "clicacert", "", "CA certificate for CLI client validation")
-	flag.Var(server.ClientAuth, "client_auth", "Client auth mode(s) - cert,password,jwt")
-	flag.Uint64Var(&jwtRefInt, "jwt_refresh_int", 30, "Seconds before JWT expiry the token can be refreshed.")
-	flag.Uint64Var(&jwtValInt, "jwt_valid_int", 3600, "Seconds that JWT token is valid for.")
+	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - cert,password,jwt")
 	flag.Parse()
 	// Suppress warning messages related to logging before flag parse
 	flag.CommandLine.Parse([]string{})
@@ -95,17 +92,17 @@ func main() {
 		}
 	}()
 
-	if caFile == "" && server.ClientAuth.Enabled("cert") {
+	if caFile == "" && clientAuth.Enabled("cert") {
 		glog.Fatal("Must specify -cacert with -client_auth cert")
 	}
 
 	swagger.Load()
 
 	server.GenerateJwtSecretKey()
-	server.JwtRefreshInt = time.Duration(jwtRefInt * uint64(time.Second))
-	server.JwtValidInt = time.Duration(jwtValInt * uint64(time.Second))
+	server.JwtRefreshInt = time.Duration(30 * uint64(time.Second))
+	server.JwtValidInt = time.Duration(3600 * uint64(time.Second))
 
-	router := server.NewRouter()
+	router := server.NewRouter(clientAuth)
 
 	address := fmt.Sprintf(":%d", port)
 
@@ -140,8 +137,7 @@ func main() {
 // unix socket. This is used for authentication of the CLI client to the REST
 // server, and will not be used for any other client.
 func spawnUnixListener() {
-	server.ClientAuth.Set("cert")
-	server.ClientAuth.Set("jwt")
+	var CLIAuth = server.UserAuth{"password": false, "cert": true, "jwt": true}
 	tlsConfig := tls.Config{
 		ClientAuth:               tls.RequireAndVerifyClientCert,
 		Certificates:             prepareServerCertificate(),
@@ -158,7 +154,7 @@ func spawnUnixListener() {
 	}
 
 	localServer := &http.Server{
-		Handler:   server.NewRouter(),
+		Handler:   server.NewRouter(CLIAuth),
 		TLSConfig: &tlsConfig,
 	}
 

--- a/src/rest/main/main.go
+++ b/src/rest/main/main.go
@@ -111,8 +111,8 @@ func main() {
 	swagger.Load()
 
 	server.GenerateJwtSecretKey()
-	server.JwtRefreshInt = time.Duration(30 * uint64(time.Second))
-	server.JwtValidInt = time.Duration(3600 * uint64(time.Second))
+	server.JwtRefreshInt = time.Duration(30 * time.Second)
+	server.JwtValidInt = time.Duration(3600 * time.Second)
 
 	router := server.NewRouter(clientAuth)
 

--- a/src/rest/main/main.go
+++ b/src/rest/main/main.go
@@ -55,7 +55,7 @@ func init() {
 	flag.StringVar(&keyFile, "key", "", "Server private key file path")
 	flag.StringVar(&caFile, "cacert", "", "CA certificate for client certificate validation")
 	flag.StringVar(&cliCAFile, "clicacert", "", "CA certificate for CLI client validation")
-	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - <none,cert,jwt,password|user(depricated)> default: password,jwt")
+	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - <none,cert,jwt,password|user(deprecated)> default: password,jwt")
 	flag.Parse()
 	// Suppress warning messages related to logging before flag parse
 	flag.CommandLine.Parse([]string{})

--- a/src/rest/main/main.go
+++ b/src/rest/main/main.go
@@ -55,10 +55,22 @@ func init() {
 	flag.StringVar(&keyFile, "key", "", "Server private key file path")
 	flag.StringVar(&caFile, "cacert", "", "CA certificate for client certificate validation")
 	flag.StringVar(&cliCAFile, "clicacert", "", "CA certificate for CLI client validation")
-	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - cert,password,jwt")
+	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - <cert,password,jwt,none> default: password,jwt")
 	flag.Parse()
 	// Suppress warning messages related to logging before flag parse
 	flag.CommandLine.Parse([]string{})
+	//Below is for setting the default client_auth to password,jwt.
+	//If you define the defaults in the above clientAuth, they will be merged together, which we don't want.
+	clientAuthFound := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "client_auth" {
+			clientAuthFound = true
+		}
+	})
+	if !clientAuthFound {
+		clientAuth = server.UserAuth{"password": true, "cert": false, "jwt": true}
+	}
+
 }
 
 var profRunning bool = true

--- a/src/rest/main/main.go
+++ b/src/rest/main/main.go
@@ -45,7 +45,7 @@ var (
 	keyFile   string // Server private key file path
 	caFile    string // Client CA certificate file path
 	cliCAFile string // CLI client CA certificate file path
-	clientAuth = server.UserAuth{"password": false, "cert": false, "jwt": false}
+	clientAuth = server.UserAuth{"password": false, "user": false, "cert": false, "jwt": false}
 )
 
 func init() {
@@ -55,7 +55,7 @@ func init() {
 	flag.StringVar(&keyFile, "key", "", "Server private key file path")
 	flag.StringVar(&caFile, "cacert", "", "CA certificate for client certificate validation")
 	flag.StringVar(&cliCAFile, "clicacert", "", "CA certificate for CLI client validation")
-	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - <cert,password,jwt,none> default: password,jwt")
+	flag.Var(clientAuth, "client_auth", "Client auth mode(s) - <none,cert,jwt,password|user(depricated)> default: password,jwt")
 	flag.Parse()
 	// Suppress warning messages related to logging before flag parse
 	flag.CommandLine.Parse([]string{})
@@ -106,6 +106,9 @@ func main() {
 
 	if caFile == "" && clientAuth.Enabled("cert") {
 		glog.Fatal("Must specify -cacert with -client_auth cert")
+	}
+	if clientAuth.Enabled("user") {
+		glog.Warning("client_auth mode \"user\" is deprecated, use \"password\" instead.")
 	}
 
 	swagger.Load()

--- a/src/rest/server/auth.go
+++ b/src/rest/server/auth.go
@@ -38,9 +38,6 @@ type UserCredential struct {
 }
 type UserAuth map[string]bool
 
-var ClientAuth = UserAuth{"password": false, "cert": false, "jwt": false, "cliuser": false}
-
-
 func (i UserAuth) String() string {
 	b := new(bytes.Buffer)
 	for key, value := range i {

--- a/src/rest/server/auth.go
+++ b/src/rest/server/auth.go
@@ -39,6 +39,9 @@ type UserCredential struct {
 type UserAuth map[string]bool
 
 func (i UserAuth) String() string {
+	if i["none"] {
+		return ""
+	}
 	b := new(bytes.Buffer)
 	for key, value := range i {
 		if value {
@@ -49,6 +52,9 @@ func (i UserAuth) String() string {
 }
 
 func (i UserAuth) Any() bool {
+	if i["none"] {
+		return false
+	}
 	for _, value := range i {
 		if value {
 			return true
@@ -58,6 +64,9 @@ func (i UserAuth) Any() bool {
 }
 
 func (i UserAuth) Enabled(mode string) bool {
+	if i["none"] {
+		return false
+	}
 	if value, exist := i[mode]; exist && value {
 		return true
 	}
@@ -68,6 +77,11 @@ func (i UserAuth) Set(mode string) error {
 	modes := strings.Split(mode, ",")
 	for _, m := range modes {
 		m = strings.Trim(m, " ")
+		if m == "none" {
+			i["none"] = true
+			return nil
+		}
+
 		if _, exist := i[m]; !exist {
 			return fmt.Errorf("Expecting one or more of 'cert', 'password' or 'jwt'")
 		}

--- a/src/rest/server/auth.go
+++ b/src/rest/server/auth.go
@@ -77,7 +77,7 @@ func (i UserAuth) Set(mode string) error {
 	modes := strings.Split(mode, ",")
 	for _, m := range modes {
 		m = strings.Trim(m, " ")
-		if m == "none" {
+		if m == "none" || m == "" {
 			i["none"] = true
 			return nil
 		}

--- a/src/rest/server/context.go
+++ b/src/rest/server/context.go
@@ -71,6 +71,9 @@ type RequestContext struct {
 
 	// Auth contains the authorized user information
 	Auth AuthInfo
+
+
+	ClientAuth UserAuth
 }
 
 type contextkey int

--- a/src/rest/server/handler.go
+++ b/src/rest/server/handler.go
@@ -38,7 +38,12 @@ import (
 func Process(w http.ResponseWriter, r *http.Request) {
 	rc, r := GetContext(r)
 	reqID := rc.ID
-	args := translibArgs{reqID: reqID, method: r.Method}
+	args := translibArgs{
+		reqID: reqID,
+		method: r.Method,
+		AuthEnabled: rc.ClientAuth.Any(),
+		User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
+	}
 
 	var err error
 	var status int
@@ -252,8 +257,9 @@ type translibArgs struct {
 	method string // method name
 	path   string // Translib path
 	data   []byte // payload
-
 	depth uint // RESTCONF depth, for Get API only
+	AuthEnabled bool //Enable Authorization
+	User translib.UserRoles // User and role info for RBAC
 }
 
 // invokeTranslib calls appropriate TransLib API for the given HTTP
@@ -271,10 +277,8 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 		req := translib.GetRequest{
 			Path:  args.path,
 			Depth: args.depth,
-			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
-		}
-		if rc.ClientAuth.Any() {
-			req.AuthEnabled = true
+			AuthEnabled: args.AuthEnabled,
+			User: args.User,
 		}
 
 		resp, err1 := translib.Get(req)
@@ -291,10 +295,8 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 			req := translib.ActionRequest{
 				Path:    args.path,
 				Payload: args.data,
-				User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
-			}
-			if rc.ClientAuth.Any() {
-				req.AuthEnabled = true
+				AuthEnabled: args.AuthEnabled,
+				User: args.User,
 			}
 			res, err1 := translib.Action(req)
 			if err1 == nil {
@@ -309,10 +311,8 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 			req := translib.SetRequest{
 				Path:    args.path,
 				Payload: args.data,
-				User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
-			}
-			if rc.ClientAuth.Any() {
-				req.AuthEnabled = true
+				AuthEnabled: args.AuthEnabled,
+				User: args.User,
 			}
 
 			_, err = translib.Create(req)
@@ -325,10 +325,8 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 		req := translib.SetRequest{
 			Path:    args.path,
 			Payload: args.data,
-			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
-		}
-		if rc.ClientAuth.Any() {
-			req.AuthEnabled = true
+			AuthEnabled: args.AuthEnabled,
+			User: args.User,
 		}
 		_, err = translib.Replace(req)
 
@@ -338,10 +336,8 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 		req := translib.SetRequest{
 			Path:    args.path,
 			Payload: args.data,
-			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
-		}
-		if rc.ClientAuth.Any() {
-			req.AuthEnabled = true
+			AuthEnabled: args.AuthEnabled,
+			User: args.User,
 		}
 		_, err = translib.Update(req)
 
@@ -350,10 +346,8 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 
 		req := translib.SetRequest{
 			Path:  args.path,
-			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
-		}
-		if rc.ClientAuth.Any() {
-			req.AuthEnabled = true
+			AuthEnabled: args.AuthEnabled,
+			User: args.User,
 		}
 		_, err = translib.Delete(req)
 

--- a/src/rest/server/handler.go
+++ b/src/rest/server/handler.go
@@ -262,7 +262,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 	var status = 400
 	var content []byte
 	var err error
-
+	
 	ts := time.Now()
 
 	switch r.Method {
@@ -273,7 +273,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 			Depth: args.depth,
 			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
 		}
-		if ClientAuth.Any() {
+		if rc.ClientAuth.Any() {
 			req.AuthEnabled = true
 		}
 
@@ -293,7 +293,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 				Payload: args.data,
 				User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
 			}
-			if ClientAuth.Any() {
+			if rc.ClientAuth.Any() {
 				req.AuthEnabled = true
 			}
 			res, err1 := translib.Action(req)
@@ -311,6 +311,9 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 				Payload: args.data,
 				User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
 			}
+			if rc.ClientAuth.Any() {
+				req.AuthEnabled = true
+			}
 
 			_, err = translib.Create(req)
 		}
@@ -324,7 +327,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 			Payload: args.data,
 			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
 		}
-		if ClientAuth.Any() {
+		if rc.ClientAuth.Any() {
 			req.AuthEnabled = true
 		}
 		_, err = translib.Replace(req)
@@ -337,7 +340,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 			Payload: args.data,
 			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
 		}
-		if ClientAuth.Any() {
+		if rc.ClientAuth.Any() {
 			req.AuthEnabled = true
 		}
 		_, err = translib.Update(req)
@@ -349,7 +352,7 @@ func invokeTranslib(args *translibArgs, r *http.Request, rc *RequestContext) (in
 			Path:  args.path,
 			User: translib.UserRoles{Name: rc.Auth.User, Roles: rc.Auth.Roles},
 		}
-		if ClientAuth.Any() {
+		if rc.ClientAuth.Any() {
 			req.AuthEnabled = true
 		}
 		_, err = translib.Delete(req)

--- a/src/rest/server/jwtAuth.go
+++ b/src/rest/server/jwtAuth.go
@@ -74,9 +74,9 @@ func tokenResp(w http.ResponseWriter, r *http.Request, username string, roles []
 
 func Authenticate(w http.ResponseWriter, r *http.Request) {
 	var creds Credentials
-
+	rc, r := GetContext(r)
 	auth_success := false
-	if ClientAuth.Enabled("cert") && r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+	if rc.ClientAuth.Enabled("cert") && r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 		//Check if they are using certificate based auth
 		username := strings.ToLower(r.TLS.PeerCertificates[0].Subject.CommonName)
 		if len(username) > 0 {

--- a/src/rest/server/restconf_test.go
+++ b/src/rest/server/restconf_test.go
@@ -31,8 +31,9 @@ import (
 func TestMetaHandler(t *testing.T) {
 	r := httptest.NewRequest("GET", "/.well-known/host-meta", nil)
 	w := httptest.NewRecorder()
+	clientAuth := UserAuth{"password": false, "cert": false, "jwt": false}
 
-	NewRouter().ServeHTTP(w, r)
+	NewRouter(clientAuth).ServeHTTP(w, r)
 
 	if w.Code != 200 {
 		t.Fatalf("Request failed with status %d", w.Code)
@@ -98,12 +99,13 @@ func TestYanglibVer_unknown(t *testing.T) {
 func testYanglibVer(t *testing.T, requestAcceptType, expectedContentType string) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/restconf/yang-library-version", nil)
+	clientAuth := UserAuth{"password": false, "cert": false, "jwt": false}
 	if requestAcceptType != "" {
 		r.Header.Set("Accept", requestAcceptType)
 	}
 
 	t.Logf("GET /restconf/yang-library-version with accept=%s", requestAcceptType)
-	NewRouter().ServeHTTP(w, r)
+	NewRouter(clientAuth).ServeHTTP(w, r)
 
 	if w.Code != 200 {
 		t.Fatalf("Request failed with status %d", w.Code)
@@ -144,13 +146,14 @@ func TestYanglibHandler(t *testing.T) {
 		rc.Produces.Add("application/yang-data+json")
 		Process(w, r)
 	}
+	clientAuth := UserAuth{"password": false, "cert": false, "jwt": false}
 
 	AddRoute("ylibTop", "GET", "/restconf/data/ietf-yang-library:modules-state", h)
 	AddRoute("ylibMset", "GET", "/restconf/data/ietf-yang-library:modules-state/module-set-id", h)
 	AddRoute("ylibOne", "GET", "/restconf/data/ietf-yang-library:modules-state/module={name},{revision}", h)
 	AddRoute("ylibNS", "GET", "/restconf/data/ietf-yang-library:modules-state/module={name},{revision}/namespace", h)
 
-	ylibRouter = NewRouter()
+	ylibRouter = NewRouter(clientAuth)
 
 	t.Run("all", testYlibGetAll)
 	t.Run("mset", testYlibGetMsetID)
@@ -249,8 +252,8 @@ func TestCapability_2(t *testing.T) {
 func testCapability(t *testing.T, path string) {
 	r := httptest.NewRequest("GET", path, nil)
 	w := httptest.NewRecorder()
-
-	NewRouter().ServeHTTP(w, r)
+	clientAuth := UserAuth{"password": false, "cert": false, "jwt": false}
+	NewRouter(clientAuth).ServeHTTP(w, r)
 
 	if w.Code != 200 {
 		t.Fatalf("Request failed with status %d", w.Code)

--- a/src/rest/server/router.go
+++ b/src/rest/server/router.go
@@ -464,7 +464,7 @@ func authMiddleware(inner http.Handler, auth UserAuth) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc, r := GetContext(r)
 		rc.ClientAuth = auth
-		glog.Infof("%s", rc.ClientAuth)
+		glog.Infof("Valid Auth Modes: %s", rc.ClientAuth)
 		var err error
 		success := false
 		ts := time.Now()

--- a/src/rest/server/router.go
+++ b/src/rest/server/router.go
@@ -464,7 +464,7 @@ func authMiddleware(inner http.Handler, auth UserAuth) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc, r := GetContext(r)
 		rc.ClientAuth = auth
-		glog.Infof("Valid Auth Modes: %s", rc.ClientAuth)
+		glog.V(2).Infof("Valid Auth Modes: %s", rc.ClientAuth)
 		var err error
 		success := false
 		ts := time.Now()

--- a/src/rest/server/router.go
+++ b/src/rest/server/router.go
@@ -138,7 +138,7 @@ type routeNode struct {
 }
 
 // add function registers a REST API info into routeTree.
-func (t *routeTree) add(parentPrefix, path string, rr *routeRegInfo) {
+func (t *routeTree) add(parentPrefix, path string, rr *routeRegInfo, auth UserAuth) {
 	root, next := pathSplit(path)
 	node := (*t)[root]
 	if node == nil {
@@ -158,14 +158,14 @@ func (t *routeTree) add(parentPrefix, path string, rr *routeRegInfo) {
 			node.handlers = make(map[string]http.Handler)
 		}
 
-		node.handlers[rr.method] = withMiddleware(rr.handler, rr.name)
+		node.handlers[rr.method] = withMiddleware(rr.handler, rr.name, auth)
 
 	} else {
 		if node.subpaths == nil {
 			node.subpaths = make(routeTree)
 		}
 
-		node.subpaths.add(node.path, next, rr)
+		node.subpaths.add(node.path, next, rr, auth)
 	}
 }
 
@@ -302,13 +302,13 @@ func AddRoute(name, method, pattern string, handler http.HandlerFunc) {
 // NewRouter creates a new http router instance for the REST server.
 // Includes all routes registered via AddRoute API as well as few
 // in-built routes.
-func NewRouter() http.Handler {
-	router := newRouter()
+func NewRouter(auth UserAuth) http.Handler {
+	router := newRouter(auth)
 	return withStat(router)
 }
 
 // newRouter creates a new Router instance from the registered routes.
-func newRouter() *Router {
+func newRouter(auth UserAuth) *Router {
 	var mb muxBuilder
 	mb.init()
 
@@ -316,7 +316,7 @@ func newRouter() *Router {
 		rcRoutes:  make(routeTree),
 		muxRoutes: mb.router,
 		optionsHandler: withMiddleware(
-			http.HandlerFunc(commonOptionsHandler), "optionsHandler"),
+			http.HandlerFunc(commonOptionsHandler), "optionsHandler", auth),
 	}
 
 	glog.Infof("Server has %d routes", len(allRoutes))
@@ -324,17 +324,17 @@ func newRouter() *Router {
 
 	for _, rr := range allRoutes {
 		if isServeFromTree(rr.path) {
-			router.rcRoutes.add("", rr.path, &rr)
+			router.rcRoutes.add("", rr.path, &rr, auth)
 			rcRouteCount++
 		} else {
-			mb.add(&rr)
+			mb.add(&rr, auth)
 			muxRouteCount++
 		}
 	}
 
 	glog.Infof("Installed %d routes on routeTree and %d on mux", rcRouteCount, muxRouteCount)
 
-	mb.finish()
+	mb.finish(auth)
 	return router
 }
 
@@ -355,23 +355,23 @@ func (mb *muxBuilder) init() {
 }
 
 // add creates a new route in mux router
-func (mb *muxBuilder) add(rr *routeRegInfo) {
+func (mb *muxBuilder) add(rr *routeRegInfo, auth UserAuth) {
 	glog.V(2).Infof("Adding %s, %s %s", rr.name, rr.method, rr.path)
 
 	mb.paths[rr.path] = true
-	h := withMiddleware(rr.handler, rr.name)
+	h := withMiddleware(rr.handler, rr.name, auth)
 	mb.router.Name(rr.name).Methods(rr.method).Path(rr.path).Handler(h)
 }
 
 // finish creates routes for all internal service API handlers in
 // mux router. Should be called after all REST API routes are added.
-func (mb *muxBuilder) finish() {
+func (mb *muxBuilder) finish(auth UserAuth) {
 	router := mb.router
 
 	// Register common OPTIONS handler for every path template
 	// New sub-router is used to avoid extra match during regular APIs
 	sr := router.Methods("OPTIONS").Subrouter()
-	oh := withMiddleware(http.HandlerFunc(commonOptionsHandler), "optionsHandler")
+	oh := withMiddleware(http.HandlerFunc(commonOptionsHandler), "optionsHandler", auth)
 	for p := range mb.paths {
 		sr.Path(p).Handler(oh)
 	}
@@ -384,11 +384,11 @@ func (mb *muxBuilder) finish() {
 	router.Methods("GET").Path("/ui").
 		Handler(http.RedirectHandler("/ui/index.html", 301))
 
-	if ClientAuth.Enabled("jwt") {
-		//Allow POST for user/pass auth and or GET for cert auth.
-		router.Methods("POST","GET").Path("/authenticate").Handler(http.HandlerFunc(Authenticate))
-		router.Methods("POST","GET").Path("/refresh").Handler(http.HandlerFunc(Refresh))
-	}
+	
+	//Allow POST for user/pass auth and or GET for cert auth.
+	router.Methods("POST","GET").Path("/authenticate").Handler(withMiddleware(http.HandlerFunc(Authenticate), "jwtAuthHandler", auth))
+	router.Methods("POST","GET").Path("/refresh").Handler(withMiddleware(http.HandlerFunc(Refresh), "jwtRefreshHandler", auth))
+	
 
 	// To download yang models
 	ydirHandler := http.FileServer(http.Dir(translib.GetYangPath()))
@@ -444,10 +444,10 @@ func loggingMiddleware(inner http.Handler, name string) http.Handler {
 
 // withMiddleware function prepares the default middleware chain for
 // REST APIs.
-func withMiddleware(h http.Handler, name string) http.Handler {
-	if ClientAuth.Any() {
-		h = authMiddleware(h)
-	}
+func withMiddleware(h http.Handler, name string, auth UserAuth) http.Handler {
+	
+	h = authMiddleware(h, auth)
+	
 
 	return loggingMiddleware(h, name)
 }
@@ -456,26 +456,32 @@ func withMiddleware(h http.Handler, name string) http.Handler {
 // authentication and authorization. This middleware will return
 // 401 response if authentication fails and 403 if authorization
 // fails.
-func authMiddleware(inner http.Handler) http.Handler {
+func authMiddleware(inner http.Handler, auth UserAuth) http.Handler {
+	if !auth.Any() {
+		return inner
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc, r := GetContext(r)
+		rc.ClientAuth = auth
+		glog.Infof("%s", rc.ClientAuth)
 		var err error
 		success := false
 		ts := time.Now()
 
-		if ClientAuth.Enabled("password") {
+		if rc.ClientAuth.Enabled("password") {
 			err = BasicAuthenAndAuthor(r, rc)
 			if err == nil {
 				success = true
 			}
 		}
-		if !success && ClientAuth.Enabled("jwt") {
+		if !success && rc.ClientAuth.Enabled("jwt") {
 			_, err = JwtAuthenAndAuthor(r, rc)
 			if err == nil {
 				success = true
 			}
 		}
-		if !success && (ClientAuth.Enabled("cert") || ClientAuth.Enabled("cliuser")) {
+		if !success && rc.ClientAuth.Enabled("cert") {
 			err = ClientCertAuthenAndAuthor(r, rc)
 			if err == nil {
 				success = true

--- a/src/rest/server/router.go
+++ b/src/rest/server/router.go
@@ -469,7 +469,7 @@ func authMiddleware(inner http.Handler, auth UserAuth) http.Handler {
 		success := false
 		ts := time.Now()
 
-		if rc.ClientAuth.Enabled("password") {
+		if rc.ClientAuth.Enabled("password") || rc.ClientAuth.Enabled("user") {
 			err = BasicAuthenAndAuthor(r, rc)
 			if err == nil {
 				success = true

--- a/src/rest/server/stats_test.go
+++ b/src/rest/server/stats_test.go
@@ -138,11 +138,12 @@ func testGetStats(reqType, rspType string) func(*testing.T) {
 	return func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/debug/stats", nil)
+		clientAuth := UserAuth{"password": false, "cert": false, "jwt": false}
 		if reqType != "" {
 			r.Header.Set("Accept", reqType)
 		}
 
-		newRouter().ServeHTTP(w, r)
+		newRouter(clientAuth).ServeHTTP(w, r)
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("Unexpected response code %d", w.Code)
@@ -158,8 +159,9 @@ func testGetStats(reqType, rspType string) func(*testing.T) {
 }
 
 func TestStats_del(t *testing.T) {
+	clientAuth := UserAuth{"password": false, "cert": false, "jwt": false}
 	w := httptest.NewRecorder()
-	newRouter().ServeHTTP(w, httptest.NewRequest("DELETE", "/debug/stats", nil))
+	newRouter(clientAuth).ServeHTTP(w, httptest.NewRequest("DELETE", "/debug/stats", nil))
 
 	if w.Code != http.StatusNoContent {
 		t.Fatalf("Unexpected response code %d", w.Code)

--- a/tools/pyang/pyang_plugins/openapi.py
+++ b/tools/pyang/pyang_plugins/openapi.py
@@ -129,9 +129,6 @@ swagger_tags = []
 swaggerDict["tags"] = swagger_tags
 swaggerDict["paths"] = OrderedDict()
 swaggerDict["definitions"] = OrderedDict()
-swaggerDict["securityDefinitions"] = {"basicAuth": {"type": "basic"}}
-swaggerDict["security"] = [{"basicAuth": []}]
-
 
 def resetDocJson():
     global docJson
@@ -165,9 +162,6 @@ def resetSwaggerDict():
     swaggerDict["tags"] = swagger_tags
     swaggerDict["paths"] = OrderedDict()
     swaggerDict["definitions"] = OrderedDict()    
-    swaggerDict["securityDefinitions"] = {"basicAuth": {"type": "basic"}}
-    swaggerDict["security"] = [{"basicAuth": []}]
-
 
 def documentFormatter(doc_obj, mdFh, mode):
     if len(doc_obj) > 0:


### PR DESCRIPTION
Don't merge yet, still needs more testing but opening PR for review.

- Use different local Auth variable for CLI and non-CLI servers and pass down via NewRouter
- Set default auth modes to password,jwt programmatically instead of relying on the config
- Add "none" auth mode that will disable all other modes even if multiple are specified.
- Remove jwt refresh/valid options and hard code values.
- Revert Swagger Spec Auth mode changes since broadcom will provide fix for Swagger UI.