### PR TITLE
Add leafrefs for acl table and rule, collector while creating ifa flow

### DIFF
--- a/models/yang/sonic/sonic-ifa.yang
+++ b/models/yang/sonic/sonic-ifa.yang
@@ -2,6 +2,14 @@ module sonic-ifa {
     namespace "http://github.com/Azure/sonic-ifa";
     prefix ifa;
 
+    import sonic-acl {
+        prefix acl;
+    }
+
+    import sonic-tam {
+        prefix tam;
+    }
+
     organization
         "SONiC";
 
@@ -49,12 +57,16 @@ module sonic-ifa {
 
                 leaf acl-table-name {
                     mandatory true;
-                    type string;
+                    type leafref {
+		        path "/acl:sonic-acl/acl:ACL_TABLE/acl:ACL_TABLE_LIST/acl:aclname";
+		    }
                 }
 
                 leaf acl-rule-name {
                     mandatory true;
-                    type string;
+                    type leafref {
+		        path "/acl:sonic-acl/acl:ACL_RULE/acl:ACL_RULE_LIST[acl:aclname=current()/../acl-table-name]/acl:rulename";
+		    }
                 }
 
                 leaf sampling-rate {
@@ -66,10 +78,9 @@ module sonic-ifa {
                 }
 
                 leaf collector-name {
-                    type string {
-                        pattern '[a-zA-Z0-9]{1}([-a-zA-Z0-9_]{0,32})';
-                        length 1..32;
-                    }
+                    type leafref {
+		        path "/tam:sonic-tam/tam:TAM_COLLECTOR_TABLE/tam:TAM_COLLECTOR_TABLE_LIST/tam:name";
+		    }
                 }
             }
         }


### PR DESCRIPTION
Adding leafref for acl table/name and collector while creating ifa flow. This was blocked earlier because of SONIC-12709 and acl table/name and collectors used regular string type. Changing them to leafref now.

~~~text
127.0.0.1:6379[4]> keys ACL*
1) "ACL_RULE|acl1|rule1"
2) "ACL_RULE|a1_ACL_IPV4|RULE_1"
3) "ACL_TABLE|a1_ACL_IPV4"
4) "ACL_TABLE|acl1"
5) "ACL_RULE|acl2|rule2"
6) "ACL_TABLE|acl2"

sonic(config-tam-int-ifa)# flow f2 acl-table acl2 acl-rule rule10
%Error: No instance found for 'rule10'
sonic(config-tam-int-ifa)# flow f2 acl-table acl20 acl-rule rule1
%Error: No instance found for 'rule1'
sonic(config-tam-int-ifa)# flow f2 acl-table acl1 acl-rule rule1

sonic(config-tam-int-ifa)# flow f3 acl-table acl1 acl-rule rule1 collector-name c1
%Error: No instance found for 'c1'
sonic(config-tam)# collector c1 type ipv4 ip 1.1.1.1 port 10
sonic(config-tam-int-ifa)# flow f3 acl-table acl1 acl-rule rule1 collector-name c1
~~~