### PR TITLE
for image install, add logic in the transformer to use proper host so…

### DIFF
--- a/scripts/host_modules/image_mgmt.py
+++ b/scripts/host_modules/image_mgmt.py
@@ -12,7 +12,12 @@ class IMAGE_MGMT(host_service.HostModule):
         """ Run config mgmt command """
         cmd = ['/usr/bin/sonic_installer']
         for x in options:
-            cmd.append(str(x))
+            if x == "-mgmt":
+                cmd.insert(0, 'cgexec')
+                cmd.insert(1, '-g')
+                cmd.insert(2, 'l3mdev:mgmt')
+            else :
+                cmd.append(str(x))
             
         output =""
         try:

--- a/src/translib/transformer/xfmr_image_mgmt.go
+++ b/src/translib/transformer/xfmr_image_mgmt.go
@@ -96,32 +96,35 @@ func image_mgmt_operation(command string, body []byte) ([]byte, error) {
             err = errors.New("ERROR:Invalid image url.") 
           }
 
-          /* Check if mgmt VRF configured */
-          d, err1 := db.NewDB(getDBOptions(db.ConfigDB))
+          if (err == nil) {
 
-          if err1 != nil {
-            log.Infof("image_mgmt_operation, unable to get configDB, error %v", err1)
-          }
+            /* Check if mgmt VRF configured */
+            d, err1 := db.NewDB(getDBOptions(db.ConfigDB))
 
-          defer d.DeleteDB()
-
-          if (err1 == nil) {
-            var MGMT_VRF_TABLE string
-            MGMT_VRF_TABLE = "MGMT_VRF_CONFIG"
-
-            mgmtVrfTable := &db.TableSpec{Name: MGMT_VRF_TABLE}
-            key := db.Key{Comp: []string{"vrf_global"}}
-
-            dbEntry, err1 := d.GetEntry(mgmtVrfTable, key)
-            if (err1 != nil) {
-                log.Info("image_mgmt_operation, mgmt vrf not found")
+            if err1 != nil {
+              log.Infof("image_mgmt_operation, unable to get configDB, error %v", err1)
             }
 
-            if (err1 == nil) {
-              mgmtVrfconfiguredStr := (&dbEntry).Get("mgmtVrfEnabled")
+            defer d.DeleteDB()
 
-              if (mgmtVrfconfiguredStr == "true") {
-                options = append(options, "-mgmt")
+            if (err1 == nil) {
+              var MGMT_VRF_TABLE string
+              MGMT_VRF_TABLE = "MGMT_VRF_CONFIG"
+
+              mgmtVrfTable := &db.TableSpec{Name: MGMT_VRF_TABLE}
+              key := db.Key{Comp: []string{"vrf_global"}}
+
+              dbEntry, err1 := d.GetEntry(mgmtVrfTable, key)
+              if (err1 != nil) {
+                log.Info("image_mgmt_operation, mgmt vrf not found")
+              }
+
+              if (err1 == nil) {
+                mgmtVrfconfiguredStr := (&dbEntry).Get("mgmtVrfEnabled")
+
+                if (mgmtVrfconfiguredStr == "true") {
+                  options = append(options, "-mgmt")
+                }
               }
             }
           }
@@ -136,7 +139,6 @@ func image_mgmt_operation(command string, body []byte) ([]byte, error) {
           if len(imagename) > 0 {
             options = append(options, imagename)
           }
-
           log.Info("Command:", options)
           query_result = HostQuery("image_mgmt.action", options)
         }

--- a/src/translib/transformer/xfmr_image_mgmt.go
+++ b/src/translib/transformer/xfmr_image_mgmt.go
@@ -95,6 +95,36 @@ func image_mgmt_operation(command string, body []byte) ([]byte, error) {
             (strings.HasPrefix(imagename, "https:") == false)) {
             err = errors.New("ERROR:Invalid image url.") 
           }
+
+          /* Check if mgmt VRF configured */
+          d, err1 := db.NewDB(getDBOptions(db.ConfigDB))
+
+          if err1 != nil {
+            log.Infof("image_mgmt_operation, unable to get configDB, error %v", err1)
+          }
+
+          defer d.DeleteDB()
+
+          if (err1 == nil) {
+            var MGMT_VRF_TABLE string
+            MGMT_VRF_TABLE = "MGMT_VRF_CONFIG"
+
+            mgmtVrfTable := &db.TableSpec{Name: MGMT_VRF_TABLE}
+            key := db.Key{Comp: []string{"vrf_global"}}
+
+            dbEntry, err1 := d.GetEntry(mgmtVrfTable, key)
+            if (err1 != nil) {
+                log.Info("image_mgmt_operation, mgmt vrf not found")
+            }
+
+            if (err1 == nil) {
+              mgmtVrfconfiguredStr := (&dbEntry).Get("mgmtVrfEnabled")
+
+              if (mgmtVrfconfiguredStr == "true") {
+                options = append(options, "-mgmt")
+              }
+            }
+          }
         }
 
         if err == nil {
@@ -105,36 +135,6 @@ func image_mgmt_operation(command string, body []byte) ([]byte, error) {
 
           if len(imagename) > 0 {
             options = append(options, imagename)
-          }
-
-          /* Check if mgmt VRF configured */
-          d, err1 := db.NewDB(getDBOptions(db.ConfigDB))
-
-          if err1 != nil {
-                log.Infof("image_mgmt_operation, unable to get configDB, error %v", err1)
-          }
-
-          defer d.DeleteDB()
-
-          if (err1 == nil) {
-              var MGMT_VRF_TABLE string
-              MGMT_VRF_TABLE = "MGMT_VRF_CONFIG"
-
-              mgmtVrfTable := &db.TableSpec{Name: MGMT_VRF_TABLE}
-              key := db.Key{Comp: []string{"vrf_global"}}
-
-              dbEntry, err1 := d.GetEntry(mgmtVrfTable, key)
-              if (err1 != nil) {
-                  log.Info("image_mgmt_operation, mgmt vrf not found")
-              }
-
-              if (err1 == nil) {
-                  mgmtVrfconfiguredStr := (&dbEntry).Get("mgmtVrfEnabled")
-
-                  if (mgmtVrfconfiguredStr == "true") {
-                      options = append(options, "-mgmt")
-                  }
-              }
           }
 
           log.Info("Command:", options)


### PR DESCRIPTION
Existing "image install' from clish uses host command "sonic_installer install <http://>". When mgmt vrf is configured, "image install" has to use "cgexec -g l3mdev:mgmt sonic_installer install <http://>"

