### PR TITLE
read from app-db for displaying pvst information

### DIFF
--- a/src/CLI/renderer/templates/show_stp.j2
+++ b/src/CLI/renderer/templates/show_stp.j2
@@ -112,11 +112,11 @@ STP Port Parameters:
             {%else %}
                 {% if vars.update({'intf_fast': "N"}) %}{% endif %}
             {%endif %}
-            {% if "openconfig-spanning-tree-ext:uplink-fast" in stp_intf['state'] and stp_intf['state']['openconfig-spanning-tree-ext:uplink-fast'] == true %}
-                {% if vars.update({'intf_ufast': "Y"}) %}{% endif %}
-            {%else %}
-                {% if vars.update({'intf_ufast': "N"}) %}{% endif %}
-            {%endif %}
+        {%endif %}
+        {% if stp_intf['config']['openconfig-spanning-tree-ext:uplink-fast'] == true %}
+            {% if vars.update({'intf_ufast': "Y"}) %}{% endif %}
+        {%else %}
+            {% if vars.update({'intf_ufast': "N"}) %}{% endif %}
         {%endif %}
 {{'%-16s'|format(vars.intf_name)}}{{'%-5s'|format(vars.intf_pri)}}{{'%-10s'|format(vars.intf_path_cost)}}{{'%-5s'|format(vars.intf_fast)}}{{'%-7s'|format(vars.intf_ufast)}}{{'%-7s'|format(vars.intf_bpdu_filter)}}{{'%-11s'|format(vars.intf_state)}}{{'%-11s'|format(vars.intf_desig_cost)}}{{'%-17s'|format(vars.intf_desig_root)}}{{'%-17s'|format(vars.intf_desig_bridge)}}
         {%endif %}

--- a/src/CLI/renderer/templates/show_stp.j2
+++ b/src/CLI/renderer/templates/show_stp.j2
@@ -101,21 +101,23 @@ STP Port Parameters:
             {% if vars.update({'intf_desig_root':intf['state']['designated-root-address']}) %}{% endif %}
             {% if vars.update({'intf_desig_bridge':intf['state']['designated-bridge-address']}) %}{% endif %}
         {%endif %}
-                {% if stp_intf['config']['bpdu-filter'] == true %}
-                   {% if vars.update({'intf_bpdu_filter': "Y"}) %}{% endif %}
-                {%else %}
-                   {% if vars.update({'intf_bpdu_filter': "N"}) %}{% endif %}
-                {%endif %}
-                {% if stp_intf['config']['openconfig-spanning-tree-ext:portfast'] == true %}
-                   {% if vars.update({'intf_fast': "Y"}) %}{% endif %}
-                {%else %}
-                   {% if vars.update({'intf_fast': "N"}) %}{% endif %}
-                {%endif %}
-                {% if stp_intf['config']['openconfig-spanning-tree-ext:uplink-fast'] == true %}
-                   {% if vars.update({'intf_ufast': "Y"}) %}{% endif %}
-                {%else %}
-                   {% if vars.update({'intf_ufast': "N"}) %}{% endif %}
-                {%endif %}
+        {% if "state" is in stp_intf %}
+            {% if "bpdu-filter" in stp_intf['state'] and if stp_intf['state']['bpdu-filter'] == true %}
+                {% if vars.update({'intf_bpdu_filter': "Y"}) %}{% endif %}
+            {%else %}
+                {% if vars.update({'intf_bpdu_filter': "N"}) %}{% endif %}
+            {%endif %}
+            {% if "openconfig-spanning-tree-ext:portfast" in stp_intf['state'] and if stp_intf['state']['openconfig-spanning-tree-ext:portfast'] == true %}
+                {% if vars.update({'intf_fast': "Y"}) %}{% endif %}
+            {%else %}
+                {% if vars.update({'intf_fast': "N"}) %}{% endif %}
+            {%endif %}
+            {% if "openconfig-spanning-tree-ext:uplink-fast" in stp_intf['state'] and stp_intf['state']['openconfig-spanning-tree-ext:uplink-fast'] == true %}
+                {% if vars.update({'intf_ufast': "Y"}) %}{% endif %}
+            {%else %}
+                {% if vars.update({'intf_ufast': "N"}) %}{% endif %}
+            {%endif %}
+        {%endif %}
 {{'%-16s'|format(vars.intf_name)}}{{'%-5s'|format(vars.intf_pri)}}{{'%-10s'|format(vars.intf_path_cost)}}{{'%-5s'|format(vars.intf_fast)}}{{'%-7s'|format(vars.intf_ufast)}}{{'%-7s'|format(vars.intf_bpdu_filter)}}{{'%-11s'|format(vars.intf_state)}}{{'%-11s'|format(vars.intf_desig_cost)}}{{'%-17s'|format(vars.intf_desig_root)}}{{'%-17s'|format(vars.intf_desig_bridge)}}
         {%endif %}
         {%endfor %}


### PR DESCRIPTION
Read from state[] while displaying bpdu filter, port/uplink fast parameter status when stp mode was set to pvst.

~~~text
admin@sonic:~$ sonic-cli
ssonic# show spanning-tree
Spanning-tree Mode: PVST

VLAN 4  - STP instance 0
------------------------------------------------------------------------------------------------------------
STP Bridge Parameters:

Bridge Bridge Bridge Bridge Hold LastTopology Topology
Identifier MaxAge Hello FwdDly Time Change Change
hex sec sec sec sec sec cnt
8064b86a97e25c9c 20 2 15 1 0 0

RootBridge RootPath DesignatedBridge Root Max Hel Fwd
Identifier Cost Identifier Port Age lo Dly
hex hex sec sec sec
806480a23526485e 800 806480a23526485e Ethernet4 20 2 15

STP Port Parameters:
Port Prio Path Port Uplink BPDU State Designated Designated Designated
Num rity Cost Fast Fast Filter Cost Root bridge
Ethernet4 128 800 N N N FORWARDING 0 806480a23526485e 806480a23526485e
sonic# exit
~~~