### PR TITLE
Add facility to save and restore configuration bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,8 @@ install:
 	$(INSTALL) -D $(TOPDIR)/scripts/org.sonic.hostservice.conf $(DESTDIR)/etc/dbus-1/system.d
 	$(INSTALL) -d $(DESTDIR)/lib/systemd/system
 	$(INSTALL) -D $(TOPDIR)/scripts/sonic-hostservice.service $(DESTDIR)/lib/systemd/system
+	$(INSTALL) -d $(DESTDIR)/etc/sonic/
+	$(INSTALL) -D $(TOPDIR)/config/cfg_mgmt.json $(DESTDIR)/etc/sonic/
 
 	# Scripts for Host Account Management (HAM)
 	$(INSTALL) -D $(TOPDIR)/src/ham/hamd/etc/dbus-1/system.d/* $(DESTDIR)/etc/dbus-1/system.d/
@@ -187,6 +189,7 @@ clean: rest-clean
 	$(MAKE) -C src/cvl clean
 	rm -rf debian/.debhelper
 	(cd build && find .  -maxdepth 1 -name "gopkgs" -prune -o -not -name '.' -exec rm -rf {} +) || true
+	(cd src/ham && ./build.sh clean || true)
 
 cleanall:
 	$(MAKE) -C src/cvl cleanall

--- a/config/cfg_mgmt.json
+++ b/config/cfg_mgmt.json
@@ -1,0 +1,13 @@
+{
+    "bgp": {
+        "container": "bgp",
+        "files": [
+            "/etc/frr/bfdd.conf",
+            "/etc/frr/bgpd.conf",
+            "/etc/frr/ospfd.conf",
+            "/etc/frr/pimd.conf",
+            "/etc/frr/staticd.conf",
+            "/etc/frr/zebra.conf"
+        ]
+    }
+}

--- a/debian/sonic-host-service.install
+++ b/debian/sonic-host-service.install
@@ -1,3 +1,4 @@
 usr/lib/*
+etc/sonic/cfg_mgmt.json
 etc/dbus-1/system.d/org.sonic.hostservice.conf
 lib/systemd/system/sonic-hostservice.service

--- a/scripts/host_modules/cfg_mgmt.py
+++ b/scripts/host_modules/cfg_mgmt.py
@@ -1,9 +1,20 @@
 """ Config management handler"""
-import host_service
-import subprocess
-import os
+# pylint: disable=invalid-name
+from __future__ import print_function
 
-MOD_NAME= 'cfg_mgmt'
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+
+import host_service
+
+MOD_NAME = 'cfg_mgmt'
+
+CFG_FILE = '/etc/sonic/cfg_mgmt.json'
+DEFAULT_FILE = '/etc/sonic/sonic-config.tar'
 
 class CFG_MGMT(host_service.HostModule):
     """DBus endpoint that executes CFG_MGMT related commands """
@@ -16,44 +27,186 @@ class CFG_MGMT(host_service.HostModule):
             cmd.extend(commands)
         else:
             cmd.append(commands)
-        
-        for x in options: 
-            cmd.append(str(x)) 
-        output =""
+
+        cmd.extend(str(x) for x in options)
+        output = ""
         try:
             print("cmd", cmd)
             rc = 0
-            output= subprocess.check_output(cmd)
-            print('Output -> ',output)
+            output = subprocess.check_output(cmd)
+            print('Output -> ', output)
 
         except subprocess.CalledProcessError as err:
             print("Exception when calling get_sonic_error -> %s\n" %(err))
             rc = err.returncode
             output = err.output
-            
-        return rc,output
+
+        return rc, output
+
+    @staticmethod
+    def _docker_copy(container, _file, tempdir, copy_to_container):
+        # Copy files/folders to/from containers
+        if copy_to_container:
+            src = os.path.join(tempdir, container, _file.lstrip('/'))
+            dst = container + ':' + _file
+        else:
+            src = container + ':' + _file
+            dst = os.path.join(tempdir, container, _file.lstrip('/'))
+            try:
+                os.makedirs(os.path.dirname(dst), exist_ok=True)
+            except OSError:
+                pass
+
+        cmd = ['/usr/bin/docker', 'cp', '-aL', src, dst]
+        try:
+            rc = 0
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError as err:
+            rc = err.returncode
+
+        return rc
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
     def save(self, options):
-        return CFG_MGMT._run_command(["save","-y"], options)
+        """Save configuration"""
+        tempdir = tempfile.mkdtemp()
+        try:
+            config = self._load_config()
+            for module, modcfg in config.items():
+                destdir = os.path.join(tempdir, module)
+                os.mkdir(destdir)
+
+                container = modcfg.get('container', None)
+                if container is None:
+                    # Copy from host
+                    for _file in modcfg.get('files', []):
+                        # Copy individual files
+                        src = _file
+                        dst = os.path.join(destdir, os.path.dirname(_file.lstrip('/')))
+                        try:
+                            os.makedirs(dst, exist_ok=True)
+                        except OSError:
+                            # dir already exists
+                            pass
+                        shutil.copy(src, dst)
+
+                    for folder in modcfg.get('folders', []):
+                        # Copy directory trees
+                        src = folder
+                        dst = os.path.join(destdir, folder.lstrip('/'))
+                        shutil.copytree(src, dst, symlinks=True)
+
+                else:
+                    # Copy from container
+                    for _file in modcfg.get('files', []):
+                        self._docker_copy(container, _file, tempdir, False)
+                    for folder in modcfg.get('folders', []):
+                        self._docker_copy(container, folder, tempdir, False)
+
+            tfile = os.path.join(tempdir, 'config_db.json')
+            rc, output = CFG_MGMT._run_command(["save", "-y"], [tfile])
+            if rc != 0:
+                return rc, output
+
+            # Copy config_db.json to /etc/sonic
+            shutil.copy(tfile, '/etc/sonic')
+
+            if options:
+                filename = options[0]
+            else:
+                filename = DEFAULT_FILE
+
+            with tarfile.open(filename, 'w') as tf:
+                tf.add(tempdir, arcname='.')
+
+        finally:
+            shutil.rmtree(tempdir, ignore_errors=True)
+
+        return 0, filename
+
+    def _load_from_tar(self, load_type, options):
+        if options:
+            filename = options[0]
+        else:
+            filename = DEFAULT_FILE
+
+        tempdir = tempfile.mkdtemp()
+        try:
+            with tarfile.open(filename, 'r') as tf:
+                tf.extractall(tempdir)
+
+            config = self._load_config()
+            for module, modcfg in config.items():
+                container = modcfg.get('container', None)
+                srcdir = os.path.join(tempdir, module)
+                if container is None:
+                    # Copy from host
+                    for _file in modcfg.get('files', []):
+                        # Copy individual files
+                        src = os.path.join(srcdir, _file.lstrip('/'))
+                        dst = os.path.dirname(_file)
+                        try:
+                            os.makedirs(dst, exist_ok=True)
+                        except OSError:
+                            # dir already exists
+                            pass
+                        shutil.copy(src, dst)
+
+                    for folder in modcfg.get('folders', []):
+                        # Copy directory trees
+                        src = os.path.join(srcdir, folder.lstrip('/'))
+                        dst = folder
+                        try:
+                            # We have to shell out to /bin/cp, since copytree
+                            # will abort if the destination already exists
+                            cmd = ['/bin/cp', '-a', src, dst]
+                            subprocess.check_call(cmd)
+                        except subprocess.CalledProcessError as err:
+                            pass
+                else:
+                    # Copy to container
+                    for _file in modcfg.get('files', []):
+                        self._docker_copy(container, _file, tempdir, True)
+                    for folder in modcfg.get('folders', []):
+                        self._docker_copy(container, folder, tempdir, True)
+
+            config_db_json = os.path.join(tempdir, 'config_db.json')
+            rc, output = CFG_MGMT._run_command([load_type, "-y"], [config_db_json])
+        except (tarfile.ReadError, FileNotFoundError):
+            # Either file is not found or file is not a tarfile
+            # If options is not given, the default file will be
+            # /etc/sonic/sonic_config.tar. This file will not exist in
+            # older releases, so on upgrade to newer releases, we will need
+            # to fallback to the old `config load` command which will pull
+            # from /etc/sonic/config_db.json. If options is given, then
+            # try to read it as a tarfile, if that fails, then treat is as
+            # a config_db.json dump.
+            rc, output = CFG_MGMT._run_command([load_type, "-y"], options)
+        finally:
+            shutil.rmtree(tempdir, ignore_errors=True)
+
+        return rc, output
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
     def reload(self, options):
-        return CFG_MGMT._run_command(["reload", "-y"], options)
+        """Reload configuration and restart services"""
+        return self._load_from_tar('reload', options)
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='as', out_signature='is')
     def load(self, options):
-        return CFG_MGMT._run_command(["load", "-y"], options)
-        
+        """Load configuration"""
+        return self._load_from_tar('load', options)
+
     @staticmethod
     def _get_version():
         '''Return the SONiC version string, or NONE if command to retrieve it fails'''
         try:
-            proc = subprocess.Popen("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version", shell=True, stdout=subprocess.PIPE)
-            out,err = proc.communicate()
+            proc = subprocess.Popen("sonic-cfggen -y /etc/sonic/sonic_version.yml -v build_version",
+                                    shell=True, stdout=subprocess.PIPE)
+            out, err = proc.communicate()
             build_version_info = out.strip()
             return build_version_info.decode("utf-8")
-        except:
+        except subprocess.CalledProcessError:
             return None
 
     @staticmethod
@@ -95,18 +248,28 @@ class CFG_MGMT(host_service.HostModule):
         """ Run config mgmt command """
         rc = 1
         if option == "":
-            rc,err = CFG_MGMT._create_host_file("/pending_erase")
+            rc, err = CFG_MGMT._create_host_file("/pending_erase")
         elif option == "boot":
-            rc,err = CFG_MGMT._create_host_file("/pending_erase", "boot")
+            rc, err = CFG_MGMT._create_host_file("/pending_erase", "boot")
         elif option == "install":
-            rc,err = CFG_MGMT._create_host_file("/pending_erase", "install")
+            rc, err = CFG_MGMT._create_host_file("/pending_erase", "install")
         elif option == "no":
-            rc,err = CFG_MGMT._delete_host_file("/pending_erase")
+            rc, err = CFG_MGMT._delete_host_file("/pending_erase")
         return rc, err
 
     @host_service.method(host_service.bus_name(MOD_NAME), in_signature='s', out_signature='is')
     def write_erase(self, option):
-        return CFG_MGMT._run_command_erase(option)
+        return self._run_command_erase(option)
+
+    @staticmethod
+    def _load_config():
+        """Load configuration for save/load/reload"""
+        config = {}
+        if os.path.exists(CFG_FILE):
+            with open(CFG_FILE, 'r') as cfg:
+                config = json.load(cfg)
+
+        return config
 
 def register():
     """Return class name"""


### PR DESCRIPTION
Prior to this change, the `write memory` command in CLI would only save
the contents of the Config DB. This commit adds support so that files
can be copied from anywhere on the host, or within containers to a
bundle file (e.g. FRR configuration files from the BGP container).

The changes are driven by a configuration file that describes sets of
files and/or folders and the source location - container or host. The
Config DB is always saved and restored, regardless of the contents of
the configuration file.