### PR TITLE
validate interface IP address by rejecting reserved, invalid addresses

### DIFF
--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -1433,22 +1433,24 @@ var DbToYang_intf_ip_addr_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) 
 }
 
 func validIPv4(ipAddress string) bool {
-    ipAddress = strings.Trim(ipAddress, " ")
-
-    re, _ := regexp.Compile(`^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$`)
-    if re.MatchString(ipAddress) {
-        return true
+    /* dont allow ip addresses that start with "0." or "255."*/
+    if (strings.HasPrefix(ipAddress, "0.") || strings.HasPrefix(ipAddress, "255.")) {
+        log.Info("validIP: ip is reserved ", ipAddress)
+        return false
     }
-    return false
+
+    /* 'net' package would know if ipAddress is v4 vs v6 */
+    return (validIPv6(ipAddress))
 }
 
 func validIPv6(ip6Address string) bool {
-    ip6Address = strings.Trim(ip6Address, " ")
-    re, _ := regexp.Compile(`(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))`)
-    if re.MatchString(ip6Address) {
-        return true
+    ip := net.ParseIP(ip6Address)
+
+    if (ip.IsLinkLocalUnicast() || ip.IsUnspecified() ||  ip.IsLoopback() ||  ip.IsMulticast()) {
+        log.Info("validIP: ip is invalid ", ip6Address)
+        return false
     }
-    return false
+    return true
 }
 
 /* Get all keys for given interface tables */


### PR DESCRIPTION
Validate interface IP address to reject unspecified/multicast/loopback/link-local-unicast addresses.

~~~text
https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
http://www.cidr-report.org/as2.0/reserved-ipv6.html

sonic(conf-if-Ethernet4)# ip address 0.1.1.1/24
%Error: Invalid IPv4 address 0.1.1.1
sonic(conf-if-Ethernet4)# ip address 255.1.1.1/24
%Error: Invalid IPv4 address 255.1.1.1
sonic(conf-if-Ethernet4)# ip address 0.0.0.0/24
%Error: Invalid IPv4 address 0.0.0.0
sonic(conf-if-Ethernet4)# ip address 127.0.0.1/24
%Error: Invalid IPv4 address 127.0.0.1
sonic(conf-if-Ethernet4)# ip address 224.0.0.1/24
%Error: Invalid IPv4 address 224.0.0.1
sonic(conf-if-Ethernet4)# ip address 169.254.0.1/24
%Error: Invalid IPv4 address 169.254.0.1

sonic(conf-if-Ethernet4)# ipv6 address ::1/128
%Error: Invalid IPv6 address ::1
sonic(conf-if-Ethernet4)# ipv6 address ::0/128
%Error: Invalid IPv6 address ::0
sonic(conf-if-Ethernet4)# ipv6 address FF00::/8
%Error: Invalid IPv6 address ff00::
sonic(conf-if-Ethernet4)# ipv6 address FE80::/10
%Error: Invalid IPv6 address FE80::
~~~