### PR TITLE
add mgmt to SSH_SERVER_VRF db when mgmt VRF is created from clish

### DIFF
--- a/models/yang/sonic/sonic-ssh-server-vrf.yang
+++ b/models/yang/sonic/sonic-ssh-server-vrf.yang
@@ -1,0 +1,45 @@
+module sonic-ssh-server-vrf {
+    namespace "http://github.com/Azure/sonic-ssh-server-vrf";
+    prefix ssh-server-vrf;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "SONIC SSH VRF SERVER";
+
+    revision 2020-01-28 {
+        description
+            "Initial revision.";
+    }
+
+    container sonic-ssh-server-vrf {
+        container SSH_SERVER_VRF {
+            description "SSH VRF server configuration.";
+
+            list SSH_SERVER_VRF_LIST {
+                key "vrf_name";
+                max-elements 15;
+
+                leaf vrf_name {
+                    type string {
+                        pattern "^mgmt$" {
+                            error-message "Invalid VRF name for SSH server";
+                            error-app-tag vrf-name-ssh-invalid;
+                        }
+                    }
+                }
+
+                leaf port {
+                    type uint16;
+                    description
+                        "SSH port number";
+                }
+            }
+        }
+    }
+}
+

--- a/models/yang/sonic/sonic-ssh-server-vrf.yang
+++ b/models/yang/sonic/sonic-ssh-server-vrf.yang
@@ -26,7 +26,7 @@ module sonic-ssh-server-vrf {
 
                 leaf vrf_name {
                     type string {
-                        pattern "^mgmt$" {
+                        pattern "mgmt|Vrf[a-zA-Z0-9_-]+" {
                             error-message "Invalid VRF name for SSH server";
                             error-app-tag vrf-name-ssh-invalid;
                         }

--- a/src/translib/transformer/xfmr_vrf.go
+++ b/src/translib/transformer/xfmr_vrf.go
@@ -441,7 +441,7 @@ var YangToDb_network_instance_table_key_xfmr KeyXfmrYangToDb = func(inParams Xfm
                         (&sshVrfDbValues).Set("port", "22")
                         sshVrfMap["mgmt"] = sshVrfDbValues
 
-                        log.Infof("bingbing ssh server vrf %v", sshVrfMap)
+                        log.Infof("ssh server vrf %v", sshVrfMap)
                         resMap["SSH_SERVER_VRF"] = sshVrfMap
                         subOpMap[db.ConfigDB] = resMap
                         inParams.subOpDataMap[inParams.oper] = &subOpMap

--- a/src/translib/transformer/xfmr_vrf.go
+++ b/src/translib/transformer/xfmr_vrf.go
@@ -418,6 +418,36 @@ var YangToDb_network_instance_table_key_xfmr KeyXfmrYangToDb = func(inParams Xfm
 
         log.Info("YangToDb_network_instance_table_key_xfmr: ", vrfTbl_key)
 
+        /*
+         * For SSH to work with a VRF, the VRF name needs to be installed in the
+         * SSH_SERVER_VRF config DB. 
+         * click has a cmd to configure <vrf_name> in this table. For now, add an entry
+         * for mgmt VRF in this table when mgmt VRF is configured. Data VRF won't be added
+         * to this table. This is because in the click cmd, MAX_SSH_VRF is 15.
+         * A clish CLI is required to configure data VRF in the SSH_SERVER_VRF
+         */
+        if ((inParams.oper == CREATE) ||
+             (inParams.oper == REPLACE) ||
+             (inParams.oper == UPDATE) ||
+             (inParams.oper == DELETE)) {
+                keyName := pathInfo.Var("name")
+
+                if keyName == "mgmt" {
+                        subOpMap := make(map[db.DBNum]map[string]map[string]db.Value)
+                        resMap := make(map[string]map[string]db.Value)
+                        sshVrfMap := make(map[string]db.Value)
+
+                        sshVrfDbValues  := db.Value{Field: map[string]string{}}
+                        (&sshVrfDbValues).Set("port", "22")
+                        sshVrfMap["mgmt"] = sshVrfDbValues
+
+                        log.Infof("bingbing ssh server vrf %v", sshVrfMap)
+                        resMap["SSH_SERVER_VRF"] = sshVrfMap
+                        subOpMap[db.ConfigDB] = resMap
+                        inParams.subOpDataMap[inParams.oper] = &subOpMap
+                }
+        }
+
         return vrfTbl_key, err
 }
 


### PR DESCRIPTION
For SSH to work with a VRF, the VRF name needs to be installed in the
 SSH_SERVER_VRF config DB.
 click has a cmd to configure <vrf_name> in this table. For now, add an entry
 for mgmt VRF in this table when mgmt VRF is configured. Data VRF won't be added
 to this table. This is because in the click cmd, MAX_SSH_VRF is 15.
 A clish CLI is required to configure data VRF in the SSH_SERVER_VRF