### PR TITLE
Changing sflow agent-id ptype to PHY_INTERFACE

### DIFF
--- a/src/CLI/clitree/cli-xml/sflow.xml
+++ b/src/CLI/clitree/cli-xml/sflow.xml
@@ -109,7 +109,7 @@ limitations under the License.
       </DOCGEN>
     </COMMAND>
     <COMMAND name="sflow agent-id" help="Collector agent interface" ptype="SUBCOMMAND" mode="subcommand">
-      <PARAM name="interface" help="Interface name" ptype="STRING"/>	      
+      <PARAM name="interface" help="Interface name" ptype="PHY_INTERFACE"/>	      
       <ACTION builtin="clish_pyobj">sonic_cli_sflow patch_sonic_sflow_sonic_sflow_sflow_sflow_list_agent_id ${interface} </ACTION> 
       <DOCGEN>
           <DESCRIPTION>Configure sFlow agent interface</DESCRIPTION>


### PR DESCRIPTION
SFLOW needs to use PHY_INTERFACE type to accept values like ethernet4 or ethernet 4 for agent-id 