### PR TITLE
Fix for "no community-list with specific community"

### DIFF
--- a/src/translib/transformer/xfmr_route_policy_sets.go
+++ b/src/translib/transformer/xfmr_route_policy_sets.go
@@ -577,10 +577,6 @@ var YangToDb_community_member_fld_xfmr FieldXfmrYangToDb = func(inParams XfmrPar
         res_map["community_member@"] = ""
         return res_map, errors.New("Invalid Inputs")
     }
-    if inParams.oper == DELETE {
-        res_map["community_member@"] = ""
-        return res_map, nil
-    }
 
     pathInfo := NewPathInfo(inParams.uri)
     if len(pathInfo.Vars) <  1 {
@@ -812,10 +808,6 @@ var YangToDb_ext_community_member_fld_xfmr FieldXfmrYangToDb = func(inParams Xfm
     if inParams.param == nil {
         res_map["community_member@"] = ""
         return res_map, errors.New("Invalid Inputs")
-    }
-    if inParams.oper == DELETE {
-        res_map["community_member@"] = ""
-        return res_map, nil
     }
 
     pathInfo := NewPathInfo(inParams.uri)


### PR DESCRIPTION
SNC3576 - no community-list a specific community string is deleting all the strings with the same community list name

RootCause: 
Delete transformer returns the empty list. This delete all the communities in list.
Fix:
Delete case handled with specific community. 


