### PR TITLE
Clarify CLI help-text to specify limited role selection

### DIFF
--- a/src/CLI/clitree/cli-xml/system.xml
+++ b/src/CLI/clitree/cli-xml/system.xml
@@ -35,7 +35,7 @@
     <COMMAND name="username" help="Add new user" ptype="SUBCOMMAND" mode="subcommand">
        <PARAM name="user-name" help="User name string" ptype="STRING"></PARAM>
            <PARAM name="password" help="Clear text password " ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="passwd" help="Type clear text password string" ptype="STRING"></PARAM>
-               <PARAM name="role" help="User role" ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="rl" help="Type User role string, allowed roles are admin and operator" ptype="STRING">
+		   <PARAM name="role" help="User role" ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="rl" help="User role (admin/operator)" ptype="STRING">
 	       </PARAM>
            </PARAM>
        </PARAM>

--- a/src/CLI/clitree/cli-xml/system.xml
+++ b/src/CLI/clitree/cli-xml/system.xml
@@ -35,7 +35,7 @@
     <COMMAND name="username" help="Add new user" ptype="SUBCOMMAND" mode="subcommand">
        <PARAM name="user-name" help="User name string" ptype="STRING"></PARAM>
            <PARAM name="password" help="Clear text password " ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="passwd" help="Type clear text password string" ptype="STRING"></PARAM>
-               <PARAM name="role" help="User role" ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="rl" help="Type User role string" ptype="STRING">
+               <PARAM name="role" help="User role" ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="rl" help="Type User role string, allowed roles are admin and operator" ptype="STRING">
 	       </PARAM>
            </PARAM>
        </PARAM>

--- a/src/translib/transformer/host_acct_mgr.go
+++ b/src/translib/transformer/host_acct_mgr.go
@@ -15,8 +15,10 @@ func roleToGroup(role string) []string {
 	switch role {
 	case "admin":
 		return []string{"admin", "sudo", "docker"}
-	default:
+	case "operator":
 		return []string{"operator", "docker"}
+	default:
+		return []string{}
 	}
 }
 // hostAccountCallObject returns a dbus.BusObject which can be used to call

--- a/src/translib/transformer/host_acct_mgr.go
+++ b/src/translib/transformer/host_acct_mgr.go
@@ -15,12 +15,8 @@ func roleToGroup(role string) []string {
 	switch role {
 	case "admin":
 		return []string{"admin", "sudo", "docker"}
-	
-	case "operator":
-		return []string{"operator", "docker"}
-	
 	default:
-		return []string{}
+		return []string{"operator", "docker"}
 	}
 }
 // hostAccountCallObject returns a dbus.BusObject which can be used to call


### PR DESCRIPTION
Test results:
~~~sonic# configure terminal
sonic(config)# username testadmin password sonic role admin
sonic(config)# username testoper1 password sonic role operator
sonic(config)# username testowner password sonic role owner
~~~
~~~
admin@sonic:~$ cat /etc/passwd | grep test
testadmin:x:1005:1000::/home/testadmin:/usr/bin/sonic-launch-shell
testoper1:x:1006:37::/home/testoper1:/usr/bin/sonic-launch-shell
testowner:x:1007:37::/home/testowner:/usr/bin/sonic-launch-shell
~~~
