### PR TITLE
fix memory corruption

### DIFF
--- a/src/CLI/klish/patches/klish-2.1.4/clish/param/param.c.diff
+++ b/src/CLI/klish/patches/klish-2.1.4/clish/param/param.c.diff
@@ -260,7 +260,7 @@
 > 	}
 124a314,325
 >     /* Handle resource leak */
->         if((method == CLISH_PTYPE_METHOD_INTEGER || method == CLISH_PTYPE_METHOD_UNSIGNEDINTEGER) &&
+>         if((method == CLISH_PTYPE_METHOD_REGEXP_SELECT) &&
 >            (clish_ptype__get_usename(this->ptype) != USE_RANGE)){
 >         /* Dynamic memory is allocated and
 >          * retun pointer is assigned to range. Since at this point


### PR DESCRIPTION
RCA - The range of (unsigned)integers are not to be free'd here. This leads to double memory free.
Fix is made to free the block only for the regexp_select case.     