### PR TITLE
Enhance error handling for clish_pyobj

### DIFF
--- a/src/CLI/actioner/sonic_cli_if.py
+++ b/src/CLI/actioner/sonic_cli_if.py
@@ -335,10 +335,10 @@ def getSonicId(item):
         return ifId
     return ifName
 
-def run(func, args):   
+def run(func, args):
 
     try:
-        response = invoke_api(func, args)    
+        response = invoke_api(func, args)
         if func == 'ip_interfaces_get' or func == 'ip6_interfaces_get':
             show_cli_output(args[0], response)
             return
@@ -359,6 +359,7 @@ def run(func, args):
 
             if api_response is None:
                 print("Failed")
+                return 1
             else:
                 if func == 'get_openconfig_interfaces_interfaces_interface':
                     show_cli_output(args[1], api_response)
@@ -366,14 +367,13 @@ def run(func, args):
                     show_cli_output(args[0], api_response)
                 elif func == 'get_sonic_port_sonic_port_port_table':
                     show_cli_output(args[0], api_response)
-                else:
-                    return
         else:
             print response.error_message()
+            return 1
 
-        
     except Exception as e:
         print("%Error: Transaction Failure")
+        return 1
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
1) Handle error returned from run() function of the actioner module
     - non-zero integer return code will be treated as failure
     - return of nonetype (if "return" is called in the python script) is treated as success

2) Handle the case where run() function doesnt exist in the actioner module

**Before:**
~~~text
sonic(config)# router bgp 200
%Error: BGP is already running with AS number 100
sonic(config-router-bgp)#
~~~

**After:**
~~~text
sonic(config)# router bgp 200
%Error: BGP is already running with AS number 100
sonic(config)#
~~~