### PR TITLE
Add support to fetch neighbor information

### DIFF
--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -267,7 +267,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 nbrInfo := intfObj.Interface[ifname].Neighbors.Neighbor[ifname]
                 ygot.BuildEmptyTree(nbrInfo)
                 app.getLldpNeighInfo(&ifname, nbrInfo, &sattr)
-                payload, err = dumpIetfJson(nbrInfo, true)
+                payload, err = dumpIetfJson(nbrInfo.State, true)
                 if err != nil {
                     log.Info("Creation of nbr subtree failed!")
                     return GetResponse{Payload: payload, ErrSrc: AppErr}, err

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -232,7 +232,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
             }
 
         }
-    } else if targetUriPath == "/openconfig-lldp:lldp/interfaces/interface" {
+    } else if ((targetUriPath == "/openconfig-lldp:lldp/interfaces/interface") || (targetUriPath == "/openconfig-lldp:lldp/interfaces/interface/neighbors")) {
         intfObj := lldpIntfObj.Interfaces
         ygot.BuildEmptyTree(intfObj)
         if intfObj.Interface != nil && len(intfObj.Interface) > 0 {
@@ -244,6 +244,12 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 app.getLldpNeighInfoFromInternalMap(&ifname, ifInfo)
 
                 if *app.ygotTarget == intfObj.Interface[ifname] {
+                    payload, err = dumpIetfJson(intfObj, true)
+                    if err != nil {
+                        log.Info("Creation of subinterface subtree failed!")
+                        return GetResponse{Payload: payload, ErrSrc: AppErr}, err
+                    }
+                } else if *app.ygotTarget == intfObj.Interface[ifname].Neighbors {
                     payload, err = dumpIetfJson(intfObj, true)
                     if err != nil {
                         log.Info("Creation of subinterface subtree failed!")

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -243,13 +243,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 ygot.BuildEmptyTree(ifInfo)
                 app.getLldpNeighInfoFromInternalMap(&ifname, ifInfo)
 
-                if *app.ygotTarget == intfObj.Interface[ifname] {
-                    payload, err = dumpIetfJson(intfObj, true)
-                    if err != nil {
-                        log.Info("Creation of subinterface subtree failed!")
-                        return GetResponse{Payload: payload, ErrSrc: AppErr}, err
-                    }
-                } else if *app.ygotTarget == intfObj.Interface[ifname].Neighbors {
+                if ((*app.ygotTarget == intfObj.Interface[ifname]) || (*app.ygotTarget == intfObj.Interface[ifname].Neighbors)) {
                     payload, err = dumpIetfJson(intfObj, true)
                     if err != nil {
                         log.Info("Creation of subinterface subtree failed!")

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -267,7 +267,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 nbrInfo := intfObj.Interface[ifname].Neighbors.Neighbor[ifname]
                 ygot.BuildEmptyTree(nbrInfo)
                 app.getLldpNeighInfo(&ifname, nbrInfo, &sattr)
-                payload, err = dumpIetfJson(intfObj, true)
+                payload, err = dumpIetfJson(nbrInfo, true)
                 if err != nil {
                     log.Info("Creation of nbr subtree failed!")
                     return GetResponse{Payload: payload, ErrSrc: AppErr}, err

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -272,7 +272,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 } else {
                     nbrInfo := intfObj.Interface[ifname].Neighbors.Neighbor[ifname]
                     ygot.BuildEmptyTree(nbrInfo)
-                    app.getLldpNeighInfo(&ifname, nbrInfo, &sattr)
+                    app.getLldpNeighInfo(&ifname, nbrInfo)
                 }
                 payload, err = generateGetResponsePayload(app.path.Path, (*app.ygotRoot).(*ocbinds.Device), app.ygotTarget)
                 if err != nil {
@@ -296,37 +296,10 @@ func (app *lldpApp) processAction(dbs [db.MaxDB]*db.DB) (ActionResponse, error) 
 }
 
 /** Helper function to populate JSON response for GET request **/
-func (app *lldpApp) getLldpNeighInfo(ifName *string, ngInfo *ocbinds.OpenconfigLldp_Lldp_Interfaces_Interface_Neighbors_Neighbor, sattr *string) {
+func (app *lldpApp) getLldpNeighInfo(ifName *string, ngInfo *ocbinds.OpenconfigLldp_Lldp_Interfaces_Interface_Neighbors_Neighbor) {
     ygot.BuildEmptyTree(ngInfo)
-    tattr := "NONE"
-    // map attr name to internal ID
-    switch *sattr {
-        case "chassis-id":
-            tattr = LLDP_REMOTE_CHASS_ID
-        case "system-name":
-            tattr = LLDP_REMOTE_SYS_NAME
-        case "port-description":
-            tattr = LLDP_REMOTE_PORT_DESC
-        case "port-id-type":
-            tattr = LLDP_REMOTE_PORT_ID_SUBTYPE
-        case "system-description":
-            tattr = LLDP_REMOTE_SYS_DESC
-        case "port-id":
-            tattr = LLDP_REMOTE_PORT_ID
-        case "id":
-            tattr = LLDP_REMOTE_REM_ID
-        case "chassis-id-type":
-            tattr = LLDP_REMOTE_CHASS_ID_SUBTYPE
-        case "management-address":
-            tattr = LLDP_REMOTE_MAN_ADDR
-        default:
-            tattr = "NONE"
-    }
 
     for attr, value := range app.lldpNeighTableMap[*ifName] {
-        if (attr != tattr) {
-            continue
-        }
         switch attr {
             case LLDP_REMOTE_SYS_NAME:
                 name  := new(string)

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -223,8 +223,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
             }
             ygot.BuildEmptyTree(oneIfInfo)
             app.getLldpNeighInfoFromInternalMap(&ifname, oneIfInfo)
-
-			payload, err = generateGetResponsePayload(app.path.Path, (*app.ygotRoot).(*ocbinds.Device), app.ygotTarget)
+            payload, err = generateGetResponsePayload(app.path.Path, (*app.ygotRoot).(*ocbinds.Device), app.ygotTarget)
         }
    } else if (strings.Contains(targetUriPath, "/openconfig-lldp:lldp/interfaces/interface")) {
         intfObj := lldpIntfObj.Interfaces
@@ -235,9 +234,8 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
                 ifInfo := intfObj.Interface[ifname]
                 ygot.BuildEmptyTree(ifInfo)
                 app.getLldpNeighInfoFromInternalMap(&ifname, ifInfo)
-
-			}
-			payload, err = generateGetResponsePayload(app.path.Path, (*app.ygotRoot).(*ocbinds.Device), app.ygotTarget)
+            }
+            payload, err = generateGetResponsePayload(app.path.Path, (*app.ygotRoot).(*ocbinds.Device), app.ygotTarget)
         } else {
             log.Info("No data")
         }
@@ -261,7 +259,7 @@ func (app *lldpApp) getLldpNeighInfoFromInternalMap(ifName *string, ifInfo *ocbi
     if !ok {
         ngInfo, err = ifInfo.Neighbors.NewNeighbor(*ifName)
         if err != nil {
-            log.Info("Creation of subinterface subtree failed!")
+            log.Info("Creation of neighbor failed!")
             return
         }
     }

--- a/src/translib/lldp_app.go
+++ b/src/translib/lldp_app.go
@@ -232,7 +232,7 @@ func (app *lldpApp) processGet(dbs [db.MaxDB]*db.DB) (GetResponse, error)  {
             }
 
         }
-    } else if ((targetUriPath == "/openconfig-lldp:lldp/interfaces/interface") || (targetUriPath == "/openconfig-lldp:lldp/interfaces/interface/neighbors")) {
+    } else if ((targetUriPath == "/openconfig-lldp:lldp/interfaces/interface") || (strings.Contains(targetUriPath, "/openconfig-lldp:lldp/interfaces/interface/neighbors"))) {
         intfObj := lldpIntfObj.Interfaces
         ygot.BuildEmptyTree(intfObj)
         if intfObj.Interface != nil && len(intfObj.Interface) > 0 {


### PR DESCRIPTION
Allow get request for neighbor information in lldp app.

~~~text

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/interface=Ethernet92/neighbors" -H "accept: application/yang-data+json"
{"openconfig-lldp:interface":[{"name":"Ethernet92","neighbors":{"neighbor":[{"capabilities":{"capability":[{"name":"openconfig-lldp-types:MAC_BRIDGE","state":{"enabled":true,"name":"openconfig-lldp-types:MAC_BRIDGE"}},{"name":"openconfig-lldp-types:ROUTER","state":{"enabled":true,"name":"openconfig-lldp-types:ROUTER"}}]},"id":"Ethernet92","state":{"chassis-id":"90:b1:1c:f4:9c:9f","chassis-id-type":"MAC_ADDRESS","id":"718","management-address":"fe80::92b1:1cff:fef4:9c9f","port-description":"Ethernet92","port-id":"fortyGigE0/92","port-id-type":"LOCAL","system-description":"Debian GNU/Linux 9 (stretch) Linux 4.9.0-11-2-amd64 #1 SMP Debian 4.9.189-3+deb9u2 (2019-11-11) x86_64","system-name":"sonic"}}]}}]}spenugondaa@xenlogin-eqx-10:~$

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/interface=Ethernet88/neighbors" -H "accept: application/yang-data+json"
{"openconfig-lldp:interface":[{"name":"Ethernet88","neighbors":{"neighbor":[{"capabilities":{"capability":[{"name":"openconfig-lldp-types:MAC_BRIDGE","state":{"enabled":true,"name":"openconfig-lldp-types:MAC_BRIDGE"}},{"name":"openconfig-lldp-types:ROUTER","state":{"enabled":true,"name":"openconfig-lldp-types:ROUTER"}}]},"id":"Ethernet88","state":{"chassis-id":"90:b1:1c:f4:9c:9f","chassis-id-type":"MAC_ADDRESS","id":"718","management-address":"fe80::92b1:1cff:fef4:9c9f","port-description":"Ethernet88","port-id":"fortyGigE0/88","port-id-type":"LOCAL","system-description":"Debian GNU/Linux 9 (stretch) Linux 4.9.0-11-2-amd64 #1 SMP Debian 4.9.189-3+deb9u2 (2019-11-11) x86_64","system-name":"sonic"}}]}}]}spenugondaa@xenlogin-eqx-10:~$

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/interface=eth0/neighbors" -H "accept: application/yang-data+json"
{"openconfig-lldp:interface":[{"name":"eth0","neighbors":{"neighbor":[{"id":"eth0","state":{"chassis-id":"00:01:e8:81:e1:e9","chassis-id-type":"MAC_ADDRESS","id":"717","management-address":"","port-description":"","port-id":"GigabitEthernet 0/27","port-id-type":"INTERFACE_NAME","system-description":"","system-name":""}}]}}]}spenugondaa@xenlogin-eqx-10:~$


sonic# show lldp neighbor
-----------------------------------------------------------
LLDP Neighbors
-----------------------------------------------------------
Interface:   Ethernet88,via: LLDP
  Chassis:
    ChassisID:    90:b1:1c:f4:9c:9f
    SysName:      sonic
    SysDescr:     Debian GNU/Linux 9 (stretch) Linux 4.9.0-11-2-amd64 #1 SMP Debian 4.9.189-3+deb9u2 (2019-11-11) x86_64
    MgmtIP:       fe80::92b1:1cff:fef4:9c9f
    MgmtIP:       fe80::92b1:1cff:fef4:9c9f
    Capability:   MAC_BRIDGE, ON
    Capability:   ROUTER, ON
  Port
    PortID:       fortyGigE0/88
    PortDescr:    Ethernet88
-----------------------------------------------------------
Interface:   Ethernet92,via: LLDP
  Chassis:
    ChassisID:    90:b1:1c:f4:9c:9f
    SysName:      sonic
    SysDescr:     Debian GNU/Linux 9 (stretch) Linux 4.9.0-11-2-amd64 #1 SMP Debian 4.9.189-3+deb9u2 (2019-11-11) x86_64
    MgmtIP:       fe80::92b1:1cff:fef4:9c9f
    MgmtIP:       fe80::92b1:1cff:fef4:9c9f
    Capability:   MAC_BRIDGE, ON
--more--
    Capability:   ROUTER, ON
  Port
    PortID:       fortyGigE0/92
    PortDescr:    Ethernet92
-----------------------------------------------------------
Interface:   eth0,via: LLDP
  Chassis:
    ChassisID:    00:01:e8:81:e1:e9
    SysName:
    SysDescr:
    MgmtIP:
    MgmtIP:
  Port
    PortID:       GigabitEthernet 0/27
    PortDescr:
-----------------------------------------------------------


~~~

Fetch individual parameters under neighbors

~~~text
sonic# show lldp neighbor
-----------------------------------------------------------
LLDP Neighbors
-----------------------------------------------------------
Interface:   eth0,via: LLDP
  Chassis:
    ChassisID:    00:01:e8:81:e1:e9
    SysName:
    SysDescr:
    MgmtIP:
    MgmtIP:
  Port
    PortID:       GigabitEthernet 0/27
    PortDescr:
-----------------------------------------------------------


spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/interface=eth0/neighbors/neighbor=eth0/state/chassis-id" -H "accept: application/yang-data+json"

{"openconfig-lldp:chassis-id":"00:01:e8:81:e1:e9"}

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/interface=eth0/neighbors/neighbor=eth0/state/port-id" -H "accept: application/yang-data+json"

{"openconfig-lldp:port-id":"GigabitEthernet 0/27"}

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/interface=eth0/neighbors/neighbor=eth0/state/port-id-type" -H "accept: application/yang-data+json"

{"openconfig-lldp:port-id-type":"INTERFACE_NAME"}

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/intrface=eth0/neighbors/neighbor=eth0/state/chassis-id-type" -H "accept: application/yang-data+json"

{"openconfig-lldp:chassis-id-type":"MAC_ADDRESS"}

spenugondaa@xenlogin-eqx-10:~$ curl -k -u admin:admin123 "https://10.11.203.11/restconf/data/openconfig-lldp:lldp/interfaces/inrface=eth0/neighbors" -H "accept: application/yang-data+json"

{"openconfig-lldp:interface":[{"name":"eth0","neighbors":{"neighbor":[{"id":"eth0","state":{"chassis-id":"00:01:e8:81:e1:e9","chassis-id-type":"MAC_ADDRESS","id":"1","management-address":"","port-description":"","port-id":"GigabitEthernet 0/27","port-id-type":"INTERFACE_NAME","system-description":"","system-name":""}}]}}]}
~~~
