### PR TITLE
Bgp redistrtbl cleanup

### DIFF
--- a/src/CLI/actioner/sonic_cli_bgp.py
+++ b/src/CLI/actioner/sonic_cli_bgp.py
@@ -1123,7 +1123,7 @@ def invoke_api(func, args=[]):
         return api.patch(keypath, body)
     elif attr == 'openconfig_network_instance_network_instances_network_instance_table_connections_table_connection_config_import_policy':
         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/table-connections/table-connection={src_protocol},{dst_protocol},{address_family}/config/import-policy',
-                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
+                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF' if 'ospf' == args[2] else 'OSPF3', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
         if op == 'patch':
             body = { "openconfig-network-instance:import-policy" : [ args[3] ] }
             return api.patch(keypath, body)
@@ -1131,7 +1131,7 @@ def invoke_api(func, args=[]):
             return api.delete(keypath)
     elif attr == 'openconfig_network_instance_ext_network_instances_network_instance_table_connections_table_connection_config_metric':
         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/table-connections/table-connection={src_protocol},{dst_protocol},{address_family}/config/openconfig-network-instance-ext:metric',
-                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
+                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF' if 'ospf' == args[2] else 'OSPF3', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
         if op == 'patch':
             body = { "openconfig-network-instance-ext:metric" : int(args[3]) }
             return api.patch(keypath, body)
@@ -1139,7 +1139,7 @@ def invoke_api(func, args=[]):
             return api.delete(keypath)
     elif attr == 'openconfig_network_instance_network_instances_network_instance_table_connections_table_connection_config':
         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/table-connections/table-connection={src_protocol},{dst_protocol},{address_family}/config',
-                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
+                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF' if 'ospf' == args[2] else 'OSPF3', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
         if op == 'patch':
             body = { "openconfig-network-instance:config" : { "address-family" : args[1].split('_',1)[0] } }
             return api.patch(keypath, body)
@@ -1147,7 +1147,7 @@ def invoke_api(func, args=[]):
             return api.delete(keypath)
     elif attr == 'openconfig_network_instance_network_instances_network_instance_table_connections_table_connection':
         keypath = cc.Path('/restconf/data/openconfig-network-instance:network-instances/network-instance={name}/table-connections/table-connection={src_protocol},{dst_protocol},{address_family}',
-                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
+                name=args[0], src_protocol= "STATIC" if 'static' == args[2] else "DIRECTLY_CONNECTED" if 'connected' == args[2] else 'OSPF' if 'ospf' == args[2] else 'OSPF3', dst_protocol=IDENTIFIER, address_family=args[1].split('_',1)[0])
         if op == 'patch':
             body = { "openconfig-network-instance:table-connection": [ { "config": { "address-family": args[1].split('_',1)[0] } } ] }
             return api.patch(keypath, body)

--- a/src/CLI/clitree/cli-xml/bgp.xml
+++ b/src/CLI/clitree/cli-xml/bgp.xml
@@ -107,6 +107,9 @@ limitations under the License.
       </PARAM>
     </PARAM>
     <ACTION> for aft in IPV4_UNICAST IPV6_UNICAST ; do for proto in connected static ospf ; do&#xA;
+                 if test "$aft" = "IPV6_UNICAST" -a "$proto" = "ospf" ; then&#xA;
+                    python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_table_connections_table_connection ${vrf-name} $aft ospf3&#xA;
+                 fi&#xA;
                  python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_table_connections_table_connection ${vrf-name} $aft $proto&#xA;
              done ; done&#xA;
              python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_config ${vrf-name}&#xA;
@@ -527,7 +530,7 @@ limitations under the License.
   </COMMAND>
   <COMMAND name="no address-family ipv6" help="Enter Address Family command mode">
     <PARAM name="unicast" help="Address Family" mode="subcommand" ptype="SUBCOMMAND"/>
-    <ACTION> for proto in connected static ospf ; do&#xA;
+    <ACTION> for proto in connected static ospf ospf3 ; do&#xA;
                  python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_table_connections_table_connection ${vrf-name} IPV6_UNICAST $proto&#xA;
              done&#xA;
              python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_afi_safis_afi_safi ${vrf-name} IPV6_UNICAST&#xA;

--- a/src/CLI/clitree/cli-xml/bgp.xml
+++ b/src/CLI/clitree/cli-xml/bgp.xml
@@ -106,7 +106,11 @@ limitations under the License.
         <PARAM name="vrf-name" help="VRF Name" ptype="STRING_15" default="default"/>
       </PARAM>
     </PARAM>
-    <ACTION builtin="clish_pyobj">sonic_cli_bgp delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_config ${vrf-name}</ACTION>
+    <ACTION> for aft in IPV4_UNICAST IPV6_UNICAST ; do for proto in connected static ospf ; do&#xA;
+                 python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_table_connections_table_connection ${vrf-name} $aft $proto&#xA;
+             done ; done&#xA;
+             python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_config ${vrf-name}&#xA;
+    </ACTION>
   </COMMAND>
 </VIEW>
 
@@ -515,11 +519,19 @@ limitations under the License.
   <COMMAND name="no address-family" help="Enter Address Family command mode"/>
   <COMMAND name="no address-family ipv4" help="Enter Address Family command mode">
     <PARAM name="unicast" help="Address Family" mode="subcommand" ptype="SUBCOMMAND"/>
-    <ACTION builtin="clish_pyobj">sonic_cli_bgp delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_afi_safis_afi_safi ${vrf-name} IPV4_UNICAST</ACTION>
+    <ACTION> for proto in connected static ospf ; do&#xA;
+                 python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_table_connections_table_connection ${vrf-name} IPV4_UNICAST $proto&#xA;
+             done&#xA;
+             python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_afi_safis_afi_safi ${vrf-name} IPV4_UNICAST&#xA;
+    </ACTION>
   </COMMAND>
   <COMMAND name="no address-family ipv6" help="Enter Address Family command mode">
     <PARAM name="unicast" help="Address Family" mode="subcommand" ptype="SUBCOMMAND"/>
-    <ACTION builtin="clish_pyobj">sonic_cli_bgp delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_afi_safis_afi_safi ${vrf-name} IPV6_UNICAST</ACTION>
+    <ACTION> for proto in connected static ospf ; do&#xA;
+                 python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_table_connections_table_connection ${vrf-name} IPV6_UNICAST $proto&#xA;
+             done&#xA;
+             python $SONIC_CLI_ROOT/sonic_cli_bgp.py delete_openconfig_network_instance_network_instances_network_instance_protocols_protocol_bgp_global_afi_safis_afi_safi ${vrf-name} IPV6_UNICAST&#xA;
+    </ACTION>
   </COMMAND>
   <COMMAND name="no address-family l2vpn" help="Enter Address Family command mode">
     <PARAM name="evpn" help="Address Family" mode="subcommand" ptype="SUBCOMMAND"/>

--- a/src/CLI/clitree/cli-xml/bgp_af_ipv6.xml
+++ b/src/CLI/clitree/cli-xml/bgp_af_ipv6.xml
@@ -31,7 +31,7 @@ limitations under the License.
     <PARAM name="protocol" help="protocol" mode="switch" ptype="SUBCOMMAND">
       <PARAM name="connected" help="Connected Routes" mode="subcommand" ptype="SUBCOMMAND"/>
       <PARAM name="static" help="Static Routes" mode="subcommand" ptype="SUBCOMMAND"/>
-      <PARAM name="ospf" help="Open Shortest Path First (OSPFv2)" mode="subcommand" ptype="SUBCOMMAND"/>
+      <PARAM name="ospfv3" help="Open Shortest Path First (IPv6) (OSPFv3)" mode="subcommand" ptype="SUBCOMMAND"/>
     </PARAM>
     <PARAM name="route-map" help="Route-map reference" mode="subcommand" ptype="SUBCOMMAND" optional="true">
       <PARAM name="route-map-name" help="Route map name" ptype="STRING"/>
@@ -116,7 +116,7 @@ limitations under the License.
     <PARAM name="protocol" help="protocol" mode="switch" ptype="SUBCOMMAND">
       <PARAM name="connected" help="Connected Routes" mode="subcommand" ptype="SUBCOMMAND"/>
       <PARAM name="static" help="Static Routes" mode="subcommand" ptype="SUBCOMMAND"/>
-      <PARAM name="ospf" help="Open Shortest Path First (OSPFv2)" mode="subcommand" ptype="SUBCOMMAND"/>
+      <PARAM name="ospfv3" help="Open Shortest Path First (IPv6) (OSPFv3)" mode="subcommand" ptype="SUBCOMMAND"/>
     </PARAM>
     <PARAM name="route-map" help="Route-map reference" mode="subcommand" ptype="SUBCOMMAND" optional="true">
       <PARAM name="route-map-name" help="Route map name" ptype="STRING"/>

--- a/src/translib/transformer/xfmr_nw_inst.go
+++ b/src/translib/transformer/xfmr_nw_inst.go
@@ -123,8 +123,8 @@ var network_instance_post_xfmr PostXfmrFunc = func(inParams XfmrParams) (map[str
     retDbDataMap := (*inParams.dbDataMap)[inParams.curDb]
 
     if inParams.oper == DELETE {
-        xpath, _ := XfmrRemoveXPATHPredicates(inParams.uri)
-        log.Info("In Network-instance Post transformer for DELETE op ==> URI : ", inParams.uri, " ; XPATH : ", xpath)
+        xpath, _ := XfmrRemoveXPATHPredicates(inParams.requestUri)
+        log.Info("In Network-instance Post transformer for DELETE op ==> URI : ", inParams.requestUri, " ; XPATH : ", xpath)
 
         if del_not_allowed, found := nw_inst_del_not_allowed_map[xpath]; found && del_not_allowed {
             var err_str string = "Delete not allowed at this container"


### PR DESCRIPTION
CLI BGP fixes for
- [Eddy] Remove route_redistribute tables for no router bgp and no address-family.
- [Rathna] Changes to use inParams.requestUri instead of inParams.uri in post-xfmr to block delete for few child cntainers. Previous change was working fine. It's just a safety check
