### PR TITLE
Fix: prevent panic error during GET request 

### DIFF
--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -1298,6 +1298,8 @@ func convertIpMapToOC (intfIpMap map[string]db.Value, ifInfo *ocbinds.Openconfig
 
     subIntf = ifInfo.Subinterfaces.Subinterface[0]
     ygot.BuildEmptyTree(subIntf)
+    ygot.BuildEmptyTree(subIntf.Ipv4)
+    ygot.BuildEmptyTree(subIntf.Ipv6)
 
     for ipKey, ipdata := range intfIpMap {
         log.Info("IP address = ", ipKey)


### PR DESCRIPTION
**Test results:**

_**Before fix--**_
GET requests at IPv4/IPv6 container level was not working -  
 curl -kX GET "https://10.11.203.17/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet4/subinterfaces/subinterface=0/openconfig-if-ip:ipv4"
```diff
-curl: (52) Empty reply from server
```
Other top/lower level GET requests were working fine--
curl -kX GET "https://10.11.203.17/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet4/subinterfaces/subinterface=0" 
```
{"openconfig-interfaces:subinterface":[{"index":0,"openconfig-if-ip:ipv4":{"addresses":{"address":[{"config":{"ip":"4.4.4.4","prefix-length":24},"ip":"4.4.4.4","state":{"ip":"4.4.4.4","prefix-length":24}}]}},"openconfig-if-ip:ipv6":{"addresses":{"address":[{"config":{"ip":"2000::2","prefix-length":64},"ip":"2000::2","state":{"ip":"2000::2","prefix-length":64}}]}}}]}
```
curl -kX GET "https://10.11.203.17/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet4/subinterfaces"
```
{"openconfig-interfaces:subinterfaces":{"subinterface":[{"index":0,"openconfig-if-ip:ipv4":{"addresses":{"address":[{"config":{"ip":"4.4.4.4","prefix-length":24},"ip":"4.4.4.4","state":{"ip":"4.4.4.4","prefix-length":24}}]}},"openconfig-if-ip:ipv6":{"addresses":{"address":[{"config":{"ip":"2000::2","prefix-length":64},"ip":"2000::2","state":{"ip":"2000::2","prefix-length":64}}]}}}]}}
```
 curl -kX GET "https://10.11.203.17/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet4/subinterfaces/subinterface=0/openconfig-if-ip:ipv6/addresses" 
```
{"openconfig-if-ip:addresses":{"address":[{"config":{"ip":"2000::2","prefix-length":64},"ip":"2000::2","state":{"ip":"2000::2","prefix-length":64}}]}}
```

**Fix added to fix GET requests at IPv4/Ipv6 container level --** 
curl -kX GET "https://10.11.203.17/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet4/subinterfaces/subinterface=0/openconfig-if-ip:ipv4" 
```diff
+{"openconfig-if-ip:ipv4":{"addresses":{"address":[{"config":{"ip":"4.4.4.4","prefix-length":24},"ip":"4.4.4.4","state":{"ip":"4.4.4.4","prefix-length":24}}]}}}
```
curl -kX GET "https://10.11.203.17/restconf/data/openconfig-interfaces:interfaces/interface=Ethernet12/subinterfaces/subinterface=0/openconfig-if-ip:ipv6" 
```diff
+{"openconfig-if-ip:ipv6":{"addresses":{"address":[{"config":{"ip":"2020::2","prefix-length":64},"ip":"2020::2","state":{"ip":"2020::2","prefix-length":64}}]}}}
```
Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>