### PR TITLE
Fix GET all of sub-interfaces resulting in faster GET of all interfaces

### DIFF
--- a/models/yang/annotations/openconfig-interfaces-annot.yang
+++ b/models/yang/annotations/openconfig-interfaces-annot.yang
@@ -141,8 +141,15 @@ module openconfig-interfaces-annot {
             sonic-ext:subtree-transformer "sw_vlans_xfmr";
         }
     }
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:subinterfaces {
+        deviate add {
+            sonic-ext:table-name "NONE";
+        }
+    }
+
     deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:subinterfaces/oc-intf:subinterface {
         deviate add {
+            sonic-ext:table-transformer "intf_subintfs_table_xfmr";
             sonic-ext:key-transformer "intf_subintfs_xfmr";
         }
     }

--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -63,6 +63,7 @@ func init () {
     XlateFuncBind("YangToDb_intf_sag_ip_xfmr", YangToDb_intf_sag_ip_xfmr)
     XlateFuncBind("DbToYang_intf_sag_ip_xfmr", DbToYang_intf_sag_ip_xfmr)
     XlateFuncBind("rpc_clear_counters", rpc_clear_counters)
+    XlateFuncBind("intf_subintfs_table_xfmr", intf_subintfs_table_xfmr)
 }
 
 const (
@@ -869,6 +870,21 @@ func getDbToYangSpeed (speed string) (ocbinds.E_OpenconfigIfEthernet_ETHERNET_SP
 
 func intf_intf_tbl_key_gen (intfName string, ip string, prefixLen int, keySep string) string {
     return intfName + keySep + ip + "/" + strconv.Itoa(prefixLen)
+}
+
+var intf_subintfs_table_xfmr TableXfmrFunc = func (inParams XfmrParams) ([]string, error) {
+    var tblList []string
+
+    log.Info("intf_subintfs_table_xfmr")
+    if (inParams.oper == GET) {
+        if(inParams.dbDataMap != nil) {
+            (*inParams.dbDataMap)[db.ConfigDB]["SUBINTF_TBL"] = make(map[string]db.Value)
+            (*inParams.dbDataMap)[db.ConfigDB]["SUBINTF_TBL"]["0"] = db.Value{Field: make(map[string]string)}
+            (*inParams.dbDataMap)[db.ConfigDB]["SUBINTF_TBL"]["0"].Field["NULL"] = "NULL"
+            tblList = append(tblList, "SUBINTF_TBL")
+        }
+    }
+    return tblList, nil
 }
 
 var YangToDb_intf_subintfs_xfmr KeyXfmrYangToDb = func(inParams XfmrParams) (string, error) {


### PR DESCRIPTION
REST GET for all interfaces is slow

In the case of list instances, the transformer obtains the keys for the instances from the table-name annotation or from the list of tables returned from the table-transformer.

In the case of sub-interfaces, we only support index 0. This index information is not stored in any table in the DB and so a table-transformer/table-name annotation really cannot be used.

Currently, the table-transformer that is used at interfaces level is inherited at sub-interfaces level.

When doing a GET at the interfaces level, when the table transformer is called at the sub-interfaces level, it returns PORT as the table. On a system that has N ports, this results in the transformer instantiating N goroutines to populate the sub-interface tree for each of the M interfaces (that includes the N ethernet (port) interfaces).

Fix: Stop inheriting the interface table transformer by using table-name = NONE at sub-interfaces level. Define a new table-transformer at the sub-interface level that updates the inParams.dbDataMap with the required instance key information 