### PR TITLE
added back unintentionally deleted code for "show ip/ipv6 prefix"

### DIFF
--- a/src/CLI/actioner/sonic-cli-ip-prefix.py
+++ b/src/CLI/actioner/sonic-cli-ip-prefix.py
@@ -107,6 +107,23 @@ def invoke(func, args):
     elif func == 'ip_prefix_delete':
         keypath, body = generate_ipprefix_uri(args, 1)
         return aa.delete(keypath)
+
+    elif func == 'ip_prefix_show_all':
+        keypath = cc.Path('/restconf/data/openconfig-routing-policy:routing-policy/defined-sets/prefix-sets')
+        return aa.get(keypath)
+
+    elif func == 'ip_prefix_show_specific':
+        keypath = cc.Path('/restconf/data/openconfig-routing-policy:routing-policy/defined-sets/prefix-sets/prefix-set={name}',name=args[1])
+        return aa.get(keypath)
+
+    elif func == 'ipv6_prefix_show_all':
+        keypath = cc.Path('/restconf/data/openconfig-routing-policy:routing-policy/defined-sets/prefix-sets')
+        return aa.get(keypath)
+
+    elif func == 'ipv6_prefix_show_specific':
+        keypath = cc.Path('/restconf/data/openconfig-routing-policy:routing-policy/defined-sets/prefix-sets/prefix-set={name}',name=args[1])
+        return aa.get(keypath)
+
     else:
     	return aa.cli_not_implemented(func)
 


### PR DESCRIPTION
added back intentionally overwrote code for show ip/ipv6 prefix.

sonic# show ip prefix-list
sonic# show ipv6  prefix-list
sonic#
sonic#
sonic# configure terminal
sonic(config)# ip
ip   ipv6

sonic(config)# ip prefix-list Test permit 1.1.1.0/8
sonic(config)# ip prefix-list Test permit 4.4.0.0/16 ge 20 le 30
sonic(config)# ip prefix-list Test permit 8.8.8.0/24 ge 26
sonic(config)# ip prefix-list Test permit 9.9.9.0/24 le 30
sonic(config)# do show ip prefix-list
IP prefix list Test:
     permit 1.1.1.0/8
     permit 4.4.0.0/16 ge 20 le 30
     permit 8.8.8.0/24 ge 26 le 32
     permit 9.9.9.0/24 ge 24 le 30
sonic(config)# do show ip prefix-list test1
sonic(config)# do show ip prefix-list Test
IP prefix list Test:
     permit 1.1.1.0/8
     permit 4.4.0.0/16 ge 20 le 30
     permit 8.8.8.0/24 ge 26 le 32
     permit 9.9.9.0/24 ge 24 le 30
sonic(config)# ip prefix-list Test permit 9.9.9.0/24 le 30
sonic(config)# ip prefix-list Test1 deny
  A.B.C.D/mask  IP prefix network/length, e.g., 35.0.0.0/8

sonic(config)# ip prefix-list Test1 deny 3.3.3.0/8 ge 10
sonic(config)# ip prefix-list Test1 deny 4.4.4.0/8 le 12
sonic(config)# ip prefix-list Test1 deny 111.111.111.111

sonic(config)# ip prefix-list Test1 deny 111.111.111.111/32
sonic(config)# do show ip prefix-list
IP prefix list Test:
     permit 1.1.1.0/8
     permit 4.4.0.0/16 ge 20 le 30
     permit 8.8.8.0/24 ge 26 le 32
     permit 9.9.9.0/24 ge 24 le 30
IP prefix list Test1:
     deny 111.111.111.111/32
     deny 3.3.3.0/8 ge 10 le 32
     deny 4.4.4.0/8 ge 8 le 12
sonic(config)# do show ip prefix-list Test
IP prefix list Test:
     permit 1.1.1.0/8
     permit 4.4.0.0/16 ge 20 le 30
     permit 8.8.8.0/24 ge 26 le 32
     permit 9.9.9.0/24 ge 24 le 30
sonic(config)# do show ip prefix-list Test1
IP prefix list Test1:
     deny 111.111.111.111/32
     deny 3.3.3.0/8 ge 10 le 32
     deny 4.4.4.0/8 ge 8 le 12
sonic(config)#
sonic(config)# ipv6 prefix-list
  String  Name of a prefix list

sonic(config)# ipv6 prefix-list TestV6 permit
  A::B/mask  IPv6 prefix network/length, e.g., 3ffe::/16

sonic(config)# ipv6 prefix-list TestV6 permit 3344::22/64
sonic(config)# ipv6 prefix-list TestV6 permit 4444::22/100 ge 110 le 112
sonic(config)# ipv6 prefix-list TestV6 permit 9988::11/80
sonic(config)# ipv6 prefix-list TestV6 deny 88::11/80
sonic(config)# ipv6 prefix-list TestV6_2 deny 88::11/80
sonic(config)# ipv6 prefix-list TestV6_2 deny 5555::3333/70 le 100
sonic(config)# do show ipv6 prefix-list
IPv6 prefix list TestV6:
     permit 3344::22/64
     permit 4444::22/100 ge 110 le 112
     deny 88::11/80
     permit 9988::11/80
IPv6 prefix list TestV6_2:
     deny 5555::3333/70 ge 70 le 100
     deny 88::11/80
sonic(config)# do show ipv6 prefix-list TestV6
IPv6 prefix list TestV6:
     permit 3344::22/64
     permit 4444::22/100 ge 110 le 112
     deny 88::11/80
     permit 9988::11/80
sonic(config)# do show ipv6 prefix-list TestV6_1
sonic(config)# do show ipv6 prefix-list TestV6_2
IPv6 prefix list TestV6_2:
     deny 5555::3333/70 ge 70 le 100
     deny 88::11/80
sonic(config)#
