### PR TITLE
Delete operation on container .../openconfig-if-ip:ipv4 and .../openconfig-if-ip:ipv6 not supported.

### DIFF
--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -444,8 +444,12 @@ var intf_table_xfmr TableXfmrFunc = func (inParams XfmrParams) ([]string, error)
     		}
     	}	
     }
-	
-	if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface") == true && IntfTypeVxlan == intfType  {
+
+	if  inParams.oper == DELETE && (targetUriPath == "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/openconfig-if-ip:ipv4" ||
+        targetUriPath ==  "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/openconfig-if-ip:ipv6") {
+            return tblList, tlerr.New("DELETE operation not allowed on  this container")
+
+    } else if strings.HasPrefix(targetUriPath, "/openconfig-interfaces:interfaces/interface") == true && IntfTypeVxlan == intfType  {
 		if inParams.oper == 5 {
 			tblList = append(tblList, "VXLAN_TUNNEL")
 			tblList = append(tblList, "EVPN_NVO")


### PR DESCRIPTION
The target uri's "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/openconfig-if-ip:ipv4" and "/openconfig-interfaces:interfaces/interface/subinterfaces/subinterface/openconfig-if-ip:ipv6" do not contain key, hence for delete operation, the transformer deletes all the records in the given table.
Since the unnumbered and neighbor information under this URI is handled separately, data from all the tables cannot be returned together.
Hence "Delete" operation is not supported here,  and returning an error.