### PR TITLE
Removing Total power from show platform env output

### DIFF
--- a/src/CLI/renderer/templates/platform_env_show.j2
+++ b/src/CLI/renderer/templates/platform_env_show.j2
@@ -4,9 +4,7 @@
 {% set  subcomponent_list = subcomponent_val['subcomponent'] %}
 {% for subcomponent_inst in subcomponent_list %}
 {% set subcomp_name = subcomponent_inst['name'].strip() %}
-{% if 'Total Power' not in subcomp_name %}
 {{subcomp_name.ljust(20)}}
-{% endif %}
 {% set sub_comp_state = subcomponent_inst['state'] %}
 {% for attr1 in sub_comp_state %}
 {% if attr1 == 'openconfig-platform-ext:sensor-category' %}

--- a/src/CLI/renderer/templates/platform_env_show.j2
+++ b/src/CLI/renderer/templates/platform_env_show.j2
@@ -4,7 +4,9 @@
 {% set  subcomponent_list = subcomponent_val['subcomponent'] %}
 {% for subcomponent_inst in subcomponent_list %}
 {% set subcomp_name = subcomponent_inst['name'].strip() %}
+{% if 'Total Power' not in subcomp_name %}
 {{subcomp_name.ljust(20)}}
+{% endif %}
 {% set sub_comp_state = subcomponent_inst['state'] %}
 {% for attr1 in sub_comp_state %}
 {% if attr1 == 'openconfig-platform-ext:sensor-category' %}

--- a/src/translib/pfm_app.go
+++ b/src/translib/pfm_app.go
@@ -403,6 +403,10 @@ func (app *PlatformApp) getPlatformEnvironment (pf_comp *ocbinds.OpenconfigPlatf
     for scanner.Scan() {
         var pf_sensor_cat *ocbinds.OpenconfigPlatform_Components_Component_Subcomponents_Subcomponent_State_SensorCategory
         log.Infof("comp: %s",scanner.Text())
+        if strings.Contains(scanner.Text(), "Total Power") {
+            continue
+        }
+
         SubCatFound := false
         pf_scomp,_ := pf_comp.Subcomponents.NewSubcomponent(scanner.Text())
         ygot.BuildEmptyTree(pf_scomp)


### PR DESCRIPTION
The total power field is not consistent across all platforms and so we decided to remove it from the output.