### PR TITLE
Validating prefix length /32 for all interface types except loopback

### DIFF
--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -1042,7 +1042,7 @@ func validateIpPrefixForIntfType(ifType E_InterfaceType, ip *string, prfxLen *ui
     case IntfTypeEthernet, IntfTypeVlan, IntfTypePortChannel, IntfTypeMgmt:
         if !isValidPrefixLength(prfxLen, isIpv4) {
             log.Errorf("Invalid Mask configuration!")
-            errStr := "Prefix length 32 not supported"
+            errStr := "Prefix length " + strconv.Itoa(int(*prfxLen)) + " not supported"
             err = tlerr.InvalidArgsError{Format: errStr}
             return err
         }

--- a/src/translib/transformer/xfmr_intf.go
+++ b/src/translib/transformer/xfmr_intf.go
@@ -1042,7 +1042,7 @@ func validateIpPrefixForIntfType(ifType E_InterfaceType, ip *string, prfxLen *ui
     case IntfTypeEthernet, IntfTypeVlan, IntfTypePortChannel, IntfTypeMgmt:
         if !isValidPrefixLength(prfxLen, isIpv4) {
             log.Errorf("Invalid Mask configuration!")
-            errStr := "Prefix Length not supported"
+            errStr := "Prefix length 32 not supported"
             err = tlerr.InvalidArgsError{Format: errStr}
             return err
         }


### PR DESCRIPTION
<img width="650" alt="invalid_prefixLength" src="https://user-images.githubusercontent.com/51496803/74374023-74e5c280-4d92-11ea-9700-2afc6c8f3306.PNG">
