### PR TITLE
Validating clear mac and changing db mac entry to lower case only for comparison to match user input

### DIFF
--- a/src/CLI/actioner/sonic-cli-mac.py
+++ b/src/CLI/actioner/sonic-cli-mac.py
@@ -98,7 +98,7 @@ def run(func, args):
 
             elif args[1] == 'mac-addr': #### -- show mac address table [address <mac-address>]--- ###
                 for mac_entry in mac_entries:
-                    if args[2] == mac_entry['mac-address']:
+                    if args[2] == mac_entry['mac-address'].lower():
                         mac_table_list.append(fill_mac_info(mac_entry))
 
             elif args[1] == 'vlan': #### -- show mac address table [vlan <vlan-id>]--- ###
@@ -115,7 +115,7 @@ def run(func, args):
             elif args[1] == 'static':
                 if args[2] == 'address':
                     for mac_entry in mac_entries:
-                        if args[3] == mac_entry['mac-address'] and mac_entry['state']['entry-type'] == 'STATIC':
+                        if args[3] == mac_entry['mac-address'].lower() and mac_entry['state']['entry-type'] == 'STATIC':
                             mac_table_list.append(fill_mac_info(mac_entry))
 
                 elif args[2] == 'vlan':
@@ -137,7 +137,8 @@ def run(func, args):
             elif args[1] == 'dynamic':
                 if args[2] == 'address':
                     for mac_entry in mac_entries:
-                        if args[3] == mac_entry['mac-address'] and mac_entry['state']['entry-type'] == 'DYNAMIC':
+                        if args[3] == mac_entry['mac-address'].lower() and mac_entry['state']['entry-type'] == 'DYNAMIC':
+
                             mac_table_list.append(fill_mac_info(mac_entry))
 
                 elif args[2] == 'vlan':

--- a/src/CLI/clitree/cli-xml/mac.xml
+++ b/src/CLI/clitree/cli-xml/mac.xml
@@ -323,18 +323,12 @@ limitations under the License.
         name="clear mac"
         help="Clear MAC"
         >
-    <ACTION>
-        builtin="clish_nop"
-    </ACTION>
     </COMMAND>
 
     <COMMAND
         name="clear mac address-table"
         help="Clear MAC address table"
         >
-    <ACTION>
-        builtin="clish_nop"
-    </ACTION>
     </COMMAND>
 
     <COMMAND


### PR DESCRIPTION
UT:

sonic# clear mac address-table dynamic
% Error: The command is not completed.
sonic# 

st-sjc-s5248f-06# show mac address-table address 00:13:01:00:00:AD
-----------------------------------------------------------
VLAN         MAC-ADDRESS         TYPE         INTERFACE           
-----------------------------------------------------------
130         00:13:01:00:00:AD   DYNAMIC       Ethernet44          
st-sjc-s5248f-06# 

