### PR TITLE
Add not-supported extension to parameters in subinterface/config and state 

### DIFF
--- a/models/yang/extensions/openconfig-interfaces-ext.yang
+++ b/models/yang/extensions/openconfig-interfaces-ext.yang
@@ -168,6 +168,14 @@ module openconfig-interfaces-ext {
         deviate not-supported;
     }
 
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:subinterfaces/oc-intf:subinterface/oc-intf:config/oc-intf:description {
+        deviate not-supported;
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:subinterfaces/oc-intf:subinterface/oc-intf:config/oc-intf:enabled {
+        deviate not-supported;
+    }
+
     deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:subinterfaces/oc-intf:subinterface/oc-intf:state {
         deviate not-supported;
     }
@@ -215,6 +223,15 @@ module openconfig-interfaces-ext {
         deviate not-supported;
     }
     deviation /oc-intf:interfaces/oc-intf:interface/oc-tun:tunnel {
+        deviate not-supported;
+    }
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:ifindex {
+        deviate not-supported;
+    }
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:last-change {
+        deviate not-supported;
+    }
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:logical {
         deviate not-supported;
     }
 }

--- a/models/yang/extensions/openconfig-interfaces-ext.yang
+++ b/models/yang/extensions/openconfig-interfaces-ext.yang
@@ -234,4 +234,8 @@ module openconfig-interfaces-ext {
     deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:logical {
         deviate not-supported;
     }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-vlan:switched-vlan/oc-vlan:config/oc-vlan:native-vlan {
+        deviate not-supported;
+    }
 }

--- a/models/yang/extensions/openconfig-interfaces-ext.yang
+++ b/models/yang/extensions/openconfig-interfaces-ext.yang
@@ -225,6 +225,9 @@ module openconfig-interfaces-ext {
     deviation /oc-intf:interfaces/oc-intf:interface/oc-tun:tunnel {
         deviate not-supported;
     }
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:type {
+        deviate not-supported;
+    }
     deviation /oc-intf:interfaces/oc-intf:interface/oc-intf:state/oc-intf:ifindex {
         deviate not-supported;
     }

--- a/models/yang/extensions/openconfig-interfaces-ext.yang
+++ b/models/yang/extensions/openconfig-interfaces-ext.yang
@@ -238,4 +238,20 @@ module openconfig-interfaces-ext {
     deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-vlan:switched-vlan/oc-vlan:config/oc-vlan:native-vlan {
         deviate not-supported;
     }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:mac-address {
+        deviate not-supported;
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:enable-flow-control {
+        deviate not-supported;
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:hw-mac-address {
+        deviate not-supported;
+    }
+
+    deviation /oc-intf:interfaces/oc-intf:interface/oc-eth:ethernet/oc-eth:state/oc-eth:negotiated-port-speed {
+        deviate not-supported;
+    }
 }

--- a/src/translib/transformer/sw_vlan.go
+++ b/src/translib/transformer/sw_vlan.go
@@ -1528,8 +1528,10 @@ func getSwitchedVlanState(ifKey *string, vlanMemberMap map[string]map[string]db.
             vlanIdCast := uint16(vlanId)
             if config == true {
                 swVlan.swEthMember.Config.AccessVlan = &vlanIdCast
+                swVlan.swEthMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
              } else {
                 swVlan.swEthMember.State.AccessVlan = &vlanIdCast
+                swVlan.swEthMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_ACCESS
              }
         }
         for _, vlanName := range trunkVlans {
@@ -1544,10 +1546,11 @@ func getSwitchedVlanState(ifKey *string, vlanMemberMap map[string]map[string]db.
             if (config == true) {
                 trunkVlan, _ := swVlan.swEthMember.Config.To_OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_Config_TrunkVlans_Union(vlanIdCast)
                 swVlan.swEthMember.Config.TrunkVlans = append(swVlan.swEthMember.Config.TrunkVlans, trunkVlan)
-
+                swVlan.swEthMember.Config.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
             } else {
                 trunkVlan, _ := swVlan.swEthMember.State.To_OpenconfigInterfaces_Interfaces_Interface_Ethernet_SwitchedVlan_State_TrunkVlans_Union(vlanIdCast)
                 swVlan.swEthMember.State.TrunkVlans = append(swVlan.swEthMember.State.TrunkVlans, trunkVlan)
+                swVlan.swEthMember.State.InterfaceMode = ocbinds.OpenconfigVlan_VlanModeType_TRUNK
             }
         }
     case IntfTypePortChannel:
@@ -1675,6 +1678,11 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
 
                     log.Infof("Get is for Switched Vlan State Container!")
                     switch targetUriPath {
+                    case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config/interface-mode":
+                        err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
+                        if err != nil {
+                            return err
+                        }
                     case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/config":
                         err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
                         if err != nil {


### PR DESCRIPTION
Some of the following are not supported by schema; hence marked not-supported. ( [SNC-3695](https://jira.force10networks.com/browse/SNC-3695) )

1. Not Supported.
2. Not Supported.
3. Not Supported.
4. Not Supported.

5. 
![image](https://user-images.githubusercontent.com/55261736/75186203-54a3f500-56fc-11ea-890c-04021c5c9fc9.png)

6. 
![image](https://user-images.githubusercontent.com/55261736/75199031-e882ba80-5716-11ea-9c50-96e671d6d3b7.png)

7,8, 9, 10: Not Supported.

11.
![image](https://user-images.githubusercontent.com/55261736/75185805-91232100-56fb-11ea-9f9d-862bd537fe89.png)

12. With switchport access vlan in the interface
![image](https://user-images.githubusercontent.com/55261736/75185875-ae57ef80-56fb-11ea-91ba-d31a74ccfbc0.png)

13.  Tagged as not-supported. Swagger is not displaying it now.

14.  With switchport access vlan in the interface
![image](https://user-images.githubusercontent.com/55261736/75185971-e0695180-56fb-11ea-9b9c-95d91967d7a4.png)

15. With switchport access vlan in the interface
![image](https://user-images.githubusercontent.com/55261736/75186011-f8d96c00-56fb-11ea-9c4c-024ca848b766.png)
