### PR TITLE
Do not show mgmt VRF when it is disabled

### DIFF
--- a/src/CLI/clitree/cli-xml/interface.xml
+++ b/src/CLI/clitree/cli-xml/interface.xml
@@ -317,6 +317,31 @@ limitations under the License.
          </PARAM>
 
          <ACTION builtin="clish_pyobj">sonic_cli_if portchannel_config PortChannel${lag-id} mode=${PoMode} min-links=${min-links-value} fallback=${fallback}</ACTION>
+         <DOCGEN>
+             <DESCRIPTION>
+                 Command to configure PortChannel with optional parameters (mode, min-links, fallback)
+             </DESCRIPTION>
+             <EXAMPLE summary="PortChannel Configuration with default parameters (mode LACP, min-links 0, fallback disabled)">
+                 sonic(config)# interface PortChannel 2
+                 sonic(conf-if-po2)# 
+             </EXAMPLE>
+             <EXAMPLE summary="PortChannel Configuration with Static mode">
+                 sonic(config)# interface PortChannel 2 mode on
+                 sonic(conf-if-po2)#
+             </EXAMPLE>
+             <EXAMPLE summary="PortChannel Configuration with LACP mode">
+                 sonic(config)# interface PortChannel 2 mode active
+                 sonic(conf-if-po2)#
+             </EXAMPLE>
+             <EXAMPLE summary="PortChannel Configuration with min-links option">
+                 sonic(config)# interface PortChannel 2 min-links 1
+                 sonic(conf-if-po2)#
+             </EXAMPLE>
+             <EXAMPLE summary="PortChannel Configuration with fallback option enabled">
+                 sonic(config)# interface PortChannel 2 fallback
+                 sonic(conf-if-po2)#
+             </EXAMPLE>
+         </DOCGEN>
     </COMMAND>
 
     <COMMAND
@@ -369,6 +394,14 @@ limitations under the License.
                 >
         </PARAM>
         <ACTION builtin="clish_restcl">oper=DELETE url=/restconf/data/openconfig-interfaces:interfaces/interface=PortChannel${lag-id}</ACTION>
+        <DOCGEN>
+            <DESCRIPTION>
+                Command to delete a PortChannel
+            </DESCRIPTION>
+            <EXAMPLE summary="Remove/Delete PortChannel">
+                sonic# no interface PortChannel 2
+            </EXAMPLE>
+        </DOCGEN>
     </COMMAND>
 
     <COMMAND
@@ -410,11 +443,29 @@ limitations under the License.
                 help="NAT zone of the interface"
                 ptype="RANGE_NAT_ZONE" />
             <ACTION builtin="clish_restcl">oper=PATCH url=/restconf/data/openconfig-interfaces:interfaces/interface=${iface}/openconfig-interfaces-ext:nat-zone/config/nat-zone body={"openconfig-interfaces-ext:nat-zone": ${zone}}</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to configure NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Configure NAT Zone on a Physical interface">
+                    sonic(config)# interface Ethernet 0
+                    sonic(conf-if-Ethernet0)# nat-zone 1
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
         <COMMAND
             name="no nat-zone"
             help="Remove Nat Zone on an interface" >
             <ACTION builtin="clish_restcl">oper=DELETE url=/restconf/data/openconfig-interfaces:interfaces/interface=${iface}/openconfig-interfaces-ext:nat-zone/config/nat-zone</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to remove NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Remove NAT Zone on a Physical interface">
+                    sonic(config)# interface Ethernet 0
+                    sonic(conf-if-Ethernet0)# no nat-zone
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
 
         <COMMAND
@@ -616,11 +667,29 @@ limitations under the License.
                 help="NAT zone of the interface"
                 ptype="RANGE_NAT_ZONE" />
             <ACTION builtin="clish_restcl">oper=PATCH url=/restconf/data/openconfig-interfaces:interfaces/interface=${lo_name}/openconfig-interfaces-ext:nat-zone/config/nat-zone body={"openconfig-interfaces-ext:nat-zone": ${zone}}</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to configure NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Configure NAT Zone on a Loopback interface">
+                    sonic(config)# interface Loopback 0
+                    sonic(conf-if-lo0)# nat-zone 1
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
         <COMMAND
             name="no nat-zone"
             help="Remove Nat Zone on the interface" >
             <ACTION builtin="clish_restcl">oper=DELETE url=/restconf/data/openconfig-interfaces:interfaces/interface=${lo_name}/openconfig-interfaces-ext:nat-zone/config/nat-zone</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to remove NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Remove NAT Zone on a Loopback interface">
+                    sonic(config)# interface Loopback 0
+                    sonic(conf-if-lo0)# no nat-zone
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
 </VIEW>
 
@@ -648,11 +717,29 @@ limitations under the License.
                 help="NAT zone of the vlan"
                 ptype="RANGE_NAT_ZONE" />
             <ACTION builtin="clish_restcl">oper=PATCH url=/restconf/data/openconfig-interfaces:interfaces/interface=${vlan_name}/openconfig-interfaces-ext:nat-zone/config/nat-zone body={"openconfig-interfaces-ext:nat-zone": ${zone}}</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to configure NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Configure NAT Zone on a VLAN interface">
+                    sonic(config)# interface Vlan 5
+                    sonic(conf-if-Vlan5)# nat-zone 1
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
         <COMMAND
             name="no nat-zone"
             help="Remove Nat Zone on a vlan" >
             <ACTION builtin="clish_restcl">oper=DELETE url=/restconf/data/openconfig-interfaces:interfaces/interface=${vlan_name}/openconfig-interfaces-ext:nat-zone/config/nat-zone</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to remove NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Remove NAT Zone on a VLAN interface">
+                    sonic(config)# interface Vlan 5
+                    sonic(conf-if-Vlan5)# no nat-zone
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
 
       <COMMAND
@@ -724,11 +811,29 @@ limitations under the License.
                 help="NAT zone of the port channel"
                 ptype="RANGE_NAT_ZONE" />
             <ACTION builtin="clish_restcl">oper=PATCH url=/restconf/data/openconfig-interfaces:interfaces/interface=${po_name}/openconfig-interfaces-ext:nat-zone/config/nat-zone body={"openconfig-interfaces-ext:nat-zone": ${zone}}</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to configure NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Configure NAT Zone on a PortChannel interface">
+                    sonic(config)# interface PortChannel 2
+                    sonic(conf-if-po2)# nat-zone 1
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
         <COMMAND
             name="no nat-zone"
             help="Remove Nat Zone on a port channel" >
             <ACTION builtin="clish_restcl">oper=DELETE url=/restconf/data/openconfig-interfaces:interfaces/interface=${po_name}/openconfig-interfaces-ext:nat-zone/config/nat-zone</ACTION>
+            <DOCGEN>
+                <DESCRIPTION>
+                    Command to remove NAT Zone on an L3 interface
+                </DESCRIPTION>
+                <EXAMPLE summary="Remove NAT Zone on a PortChannel interface">
+                    sonic(config)# interface PortChannel 2
+                    sonic(conf-if-po2)# no nat-zone
+                </EXAMPLE>
+            </DOCGEN>
         </COMMAND>
 
         <COMMAND

--- a/src/CLI/clitree/cli-xml/ipv4-neighbors.xml
+++ b/src/CLI/clitree/cli-xml/ipv4-neighbors.xml
@@ -36,6 +36,7 @@ limitations under the License.
 
 <VIEW name="enable-view">
 
+
 <!-- show ip arp <ip-addr> commands -->
     <COMMAND
         help="show ARP commands"
@@ -56,6 +57,61 @@ limitations under the License.
        <ACTION>
                python $SONIC_CLI_ROOT/sonic-cli-neighbors.py get_sonic_neigh_sonic_neigh_neigh_table arp_show.j2 IPv4 ${ip-addr}&#xA;
        </ACTION>
+       <DOCGEN>
+            <DESCRIPTION>
+                This command displays ARP table entries. To filter the
+                output, specify an interface, port channel, or VLAN, an IP address, a MAC
+                address, or a combination of more than one value to match.  You can also
+                display total number of ARP entries using 'summary' option.
+            </DESCRIPTION>
+
+            <USAGE>
+                sonic# show ip arp [interface { ethernet <port> [summary] | port-channel <id> [summary] | vlan <id> [summary] }] [<A.B.C.D>] [mac-address <mac>] [summary]
+            </USAGE>
+
+            <EXAMPLE summary="show ip arp information">
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+            </EXAMPLE>
+
+             <EXAMPLE summary="show ip arp interface information">
+                sonic# show ip arp interface Vlan 100
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.3.6     00:01:02:03:04:05   Vlan100          Ethernet4
+
+                sonic# show ip arp interface Management 0
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+            </EXAMPLE>
+
+            <EXAMPLE summary="show ip arp ip information">
+                sonic# show ip arp 192.168.1.4
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+            </EXAMPLE>
+
+            <EXAMPLE summary="show ip arp mac-address information">
+                sonic# show ip arp mac-address 00:01:02:03:ab:cd
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+            </EXAMPLE>
+        </DOCGEN>
     </COMMAND>
 
 <!-- show ip arp interface <intf> [summary] -->
@@ -243,43 +299,13 @@ limitations under the License.
         </ACTION>
     </COMMAND>
 
-<!-- clear ip arp -->
+<!-- clear ip -->
     <COMMAND
         help="clear IP commands"
         name="clear ip"
         >
-    <ACTION builtin="clish_nop"/>
     </COMMAND>
 
-<!-- clear ip arp interface <intf> -->
-    <COMMAND
-        help="clear ARP entries for this interface"
-        name="clear ip arp interface">
-        <PARAM
-            name="if-type"
-            help=""
-            ptype="INTF_TYPE">
-            <PARAM
-                name="if-id"
-                help="Numeric ID for the given interface type"
-                ptype="UINT">
-            </PARAM>
-        </PARAM>
-        <PARAM
-            name="force"
-            help="Delete static or PERMENANT entries"
-            ptype="SUBCOMMAND"
-            mode="subcommand"
-            optional="true">
-        </PARAM>
-        <ACTION>
-        if test "${force}" = ""; then
-            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv4" "false" interface ${if-type}${if-id}&#xA;
-        else
-            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv4" "true" interface ${if-type}${if-id}&#xA;
-        fi
-        </ACTION>
-    </COMMAND>
 
 <!-- clear ip arp <ip> -->
     <COMMAND
@@ -312,6 +338,126 @@ limitations under the License.
             python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv4" "true" ${ip-addr}&#xA;
         fi
        </ACTION>
+       <DOCGEN>
+            <DESCRIPTION>
+                To delete dynamically learned IPv4 entries from the ARP table, use the clear ip
+                arp command. To specify the entries to be deleted, enter an interface, port
+                channel, or VLAN, an IPv4 address, or a combination to match. Enter force to
+                delete statically configured ARP entries. Use the show ip arp command to verify
+                that the IPv4 entries have been deleted.
+            </DESCRIPTION>
+
+            <USAGE>
+                sonic# clear ip arp [interface {Ethernet port-number | PortChannel number | Vlan vlan-id | Management port-number}] [ip-address] [force]
+            </USAGE>
+
+            <EXAMPLE summary="clear ip arp information">
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+                sonic# clear ip arp
+                sonic# Permanent entry found, use 'force' to delete permanent entries
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                sonic# clear ip arp force
+                sonic# show ip arp
+                sonic#
+             </EXAMPLE>
+
+             <EXAMPLE summary="clear ip arp interface information">
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+                sonic# clear ip arp interface Vlan 100 force
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+             </EXAMPLE>
+
+            <EXAMPLE summary="clear ip arp ip information">
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+                sonic# clear ip arp 192.168.1.4
+                sonic# Permanent entry found, use 'force' to delete permanent entries
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.1.4     00:01:02:03:44:55   Ethernet8         -
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+                sonic# clear ip arp 192.168.1.4 force
+                sonic# show ip arp
+                ---------------------------------------------------------------------
+                Address         Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------
+                192.168.2.4     00:01:02:03:ab:cd   PortChannel200    -
+                192.168.3.6     00:01:02:03:04:05   Vlan100           Ethernet4
+                10.11.48.254    00:01:e8:8b:44:71   eth0              -
+                10.14.8.102     00:01:e8:8b:44:71   eth0              -
+            </EXAMPLE>
+        </DOCGEN>
+    </COMMAND>
+
+<!-- clear ip arp interface <intf> -->
+    <COMMAND
+        help="clear ARP entries for this interface"
+        name="clear ip arp interface">
+        <PARAM
+            name="if-type"
+            help=""
+            ptype="INTF_TYPE">
+            <PARAM
+                name="if-id"
+                help="Numeric ID for the given interface type"
+                ptype="UINT">
+            </PARAM>
+        </PARAM>
+        <PARAM
+            name="force"
+            help="Delete static or PERMENANT entries"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+            optional="true">
+        </PARAM>
+        <ACTION>
+        if test "${force}" = ""; then
+            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv4" "false" interface ${if-type}${if-id}&#xA;
+        else
+            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv4" "true" interface ${if-type}${if-id}&#xA;
+        fi
+        </ACTION>
     </COMMAND>
 </VIEW>
 </CLISH_MODULE>

--- a/src/CLI/clitree/cli-xml/ipv6-neighbors.xml
+++ b/src/CLI/clitree/cli-xml/ipv6-neighbors.xml
@@ -56,6 +56,59 @@ limitations under the License.
        <ACTION>
                python $SONIC_CLI_ROOT/sonic-cli-neighbors.py get_sonic_neigh_sonic_neigh_neigh_table arp_show.j2 IPv6 ${ipv6-addr}&#xA;
        </ACTION>
+       <DOCGEN>
+            <DESCRIPTION>
+                This command displays NDP table entries. To filter the
+                output, specify an interface, port channel, or VLAN, an IPv6 address, a MAC
+                address, or a combination of more than one value to match.  You can also
+                display total number of ARP entries using 'summary' option.
+            </DESCRIPTION>
+
+            <USAGE>
+                sonic# show ipv6 neighbors [interface { ethernet <port> [summary] | port-channel <id> [summary] | vlan <id> [summary] }] [ipv6-address] [mac-address <mac>] [summary]
+            </USAGE>
+
+            <EXAMPLE summary="show ipv6 neighbors information">
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+                fe80::e6f0:4ff:fe79:34c7    00:01:e8:8b:44:71   eth0              -
+            </EXAMPLE>
+
+             <EXAMPLE summary="show ipv6 neighbors interface information">
+                sonic# show ipv6 neighbors Vlan 100
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+
+                sonic# show ipv6 neighbors interface Management 0
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                fe80::e6f0:4ff:fe79:34c7    00:01:e8:8b:44:71   eth0              -
+            </EXAMPLE>
+
+            <EXAMPLE summary="show ipv6 neighbors ip information">
+                sonic# show ipv6 neighbors 20::2
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+            </EXAMPLE>
+
+            <EXAMPLE summary="show ipv6 neighbors mac-address information">
+                sonic# show ipv6 neighbors mac-address 00:01:02:03:04:05
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+            </EXAMPLE>
+        </DOCGEN>
     </COMMAND>
 
 <!-- show ipv6 neighbors interface <intf> [summary] -->
@@ -116,38 +169,8 @@ limitations under the License.
         help="clear IP commands"
         name="clear ipv6"
         >
-    <ACTION builtin="clish_nop"/>
     </COMMAND>
 
-<!-- clear ipv6 neighbors interface <intf> -->
-    <COMMAND
-        help="clear NDP entries for this interface"
-        name="clear ipv6 neighbors interface">
-        <PARAM
-            name="if-type"
-            help=""
-            ptype="INTF_TYPE">
-            <PARAM
-                name="if-id"
-                help="Numeric ID for the given interface type"
-                ptype="UINT">
-            </PARAM>
-        </PARAM>
-        <PARAM
-            name="force"
-            help="Delete static or PERMENANT entries"
-            ptype="SUBCOMMAND"
-            mode="subcommand"
-            optional="true">
-        </PARAM>
-        <ACTION>
-        if test "${force}" = ""; then&#xA;
-            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv6" "false" interface ${if-type}${if-id}&#xA;
-        else&#xA;
-            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv6" "true" interface ${if-type}${if-id}&#xA;
-        fi&#xA;
-        </ACTION>
-    </COMMAND>
 
 <!-- clear ipv6 neighbors <ip> -->
     <COMMAND
@@ -180,6 +203,105 @@ limitations under the License.
             python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv6" "true" ${ip-addr}&#xA;
         fi&#xA;
        </ACTION>
+       <DOCGEN>
+            <DESCRIPTION>
+                To delete dynamically learned IPv6 entries from the NDP table, use the 'clear ipv6 neighbor' command.
+                To specify the entries to be deleted, enter an interface, port channel, or VLAN, an IPv6 address, or a combination to match.
+                Enter 'force' to delete statically configured NDP entries. Use the 'show ipv6 neighbors' to verify that the IPv6 entries have been deleted.
+            </DESCRIPTION>
+
+            <USAGE>
+                sonic# clear ipv6 neighbors [interface {Ethernet port-number | PortChannel number | Vlan vlan-id | Management port-number}] [ipv6-address] [force]
+            </USAGE>
+
+            <EXAMPLE summary="clear ipv6 neighbors information">
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+                fe80::e6f0:4ff:fe79:34c7    00:01:e8:8b:44:71   eth0              -
+                sonic# clear ipv6 neighbors
+                sonic# Permanent entry found, use 'force' to delete permanent entries
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+             </EXAMPLE>
+
+            <EXAMPLE summary="clear ipv6 neighbors interface information">
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+                fe80::e6f0:4ff:fe79:34c7    00:01:e8:8b:44:71   eth0              -
+                sonic# clear ipv6 neighbors interface Vlan 100 force
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                fe80::e6f0:4ff:fe79:34c7    00:01:e8:8b:44:71   eth0              -
+            </EXAMPLE>
+
+            <EXAMPLE summary="clear ipv6 neighbors ip information">
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+                fe80::e6f0:4ff:fe79:34c7    00:01:e8:8b:44:71   eth0              -
+                sonic# clear ipv6 neighbors fe80::e6f0:4ff:fe79:34c7
+                sonic# show ipv6 neighbors
+                ---------------------------------------------------------------------------------
+                Address                     Hardware address    Interface        Egress Interface
+                ---------------------------------------------------------------------------------
+                20::1                       00:01:02:03:44:55   Ethernet8         -
+                20::2                       00:01:02:03:ab:cd   PortChannel200    -
+                20::3                       00:01:02:03:04:05   Vlan100           Ethernet4
+            </EXAMPLE>
+        </DOCGEN>
+    </COMMAND>
+
+<!-- clear ipv6 neighbors interface <intf> -->
+    <COMMAND
+        help="clear NDP entries for this interface"
+        name="clear ipv6 neighbors interface">
+        <PARAM
+            name="if-type"
+            help=""
+            ptype="INTF_TYPE">
+            <PARAM
+                name="if-id"
+                help="Numeric ID for the given interface type"
+                ptype="UINT">
+            </PARAM>
+        </PARAM>
+        <PARAM
+            name="force"
+            help="Delete static or PERMENANT entries"
+            ptype="SUBCOMMAND"
+            mode="subcommand"
+            optional="true">
+        </PARAM>
+        <ACTION>
+        if test "${force}" = ""; then&#xA;
+            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv6" "false" interface ${if-type}${if-id}&#xA;
+        else&#xA;
+            python $SONIC_CLI_ROOT/sonic-cli-neighbors.py rpc_sonic_clear_neighbors "IPv6" "true" interface ${if-type}${if-id}&#xA;
+        fi&#xA;
+        </ACTION>
     </COMMAND>
 </VIEW>
 </CLISH_MODULE>

--- a/src/CLI/clitree/cli-xml/tacacs.xml
+++ b/src/CLI/clitree/cli-xml/tacacs.xml
@@ -68,6 +68,18 @@ limitations under the License.
              mode="subcommand" 
              ptype="SUBCOMMAND">
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py get_sonic_tacacs_global show_tacacs_global.j2</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Displays global configuration for tacacs servers. Global parameters are considered if a particular
+              server is not configured with that parameter. 
+          </DESCRIPTION>
+          <USAGE>
+             Use the show command to display tacacs server global parameters. 
+          </USAGE>
+          <EXAMPLE summary="Display tacacs server global parameters">
+              sonic# show tacacs-server global
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
     <COMMAND name="show tacacs-server host" 
              help="Show tacacs server configuration" 
@@ -85,6 +97,30 @@ limitations under the License.
           python $SONIC_CLI_ROOT/sonic-cli-tacacs.py get_sonic_tacacs_server ${address} show_tacacs_server.j2;
         fi
       </ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Displays configured properties of tacacs server(s).
+          </DESCRIPTION>
+          <USAGE>
+              Use the command to display properties of tacacs server(s). Use IP address of the server, to
+              display particular server's configuration. If nothing is specified, displays all the servers.
+          </USAGE>
+          <EXAMPLE summary="Display all tacacs servers">
+sonic# show tacacs-server host
+------------------------------------------------------------------------------------------------
+HOST                 AUTH-TYPE       KEY        PORT       PRIORITY   TIMEOUT
+------------------------------------------------------------------------------------------------
+1.1.1.1              pap             mykey      10         10         10
+2.2.2.2              pap             mykey      20         20         20
+          </EXAMPLE>
+          <EXAMPLE summary="Display specific tacacs server">
+sonic# show tacacs-server host 1.1.1.1
+------------------------------------------------------------------------------------------------
+HOST                 AUTH-TYPE       KEY        PORT       PRIORITY   TIMEOUT
+------------------------------------------------------------------------------------------------
+1.1.1.1              pap             mykey      10         10         10
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
   </VIEW>
 
@@ -103,6 +139,22 @@ limitations under the License.
              ptype="IPV4V6_ADDR">
       </PARAM>
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_source_address ${src-ip}</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+               Specify an IP address is used as the source IP address for user authentication with a TACACS+ server in
+               CONFIGURATION mode. By default, no source ip address is configured as the IP address of the interface from
+               which a packet is sent to a TACACS+ server is used as source IP in the packet.
+          </DESCRIPTION>
+          <USAGE>
+               Configure a valid v4 or v6 address as source IP in config mode.
+          </USAGE>
+          <EXAMPLE summary="Configuring global source ip to communicate with tacacs server">
+sonic# configure
+sonic(config)# tacacs-server source-ip
+  A.B.C.D/A::B
+sonic(config)# tacacs-server source-ip 1.2.3.4
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <!-- tacacs timeout -->
@@ -115,6 +167,21 @@ limitations under the License.
              ptype="TACACS_TIMEOUT">
       </PARAM>
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_timeout ${timeout}</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Configure the global timeout used to wait for an authentication response from TACACS+ servers in CONFIGURATION mode, from 1 to
+              60 seconds; the default is 5.
+          </DESCRIPTION>
+          <USAGE>
+               Configure global timeout value in config mode.
+          </USAGE>
+          <EXAMPLE summary="Configuring global timeout to wait for response from tacacs server">
+sonic# configure
+sonic(config)# tacacs-server timeout
+  seconds  timeout (default: 5) (0..60)
+sonic(config)# tacacs-server timeout 10
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <!-- tacacs authtype -->
@@ -127,6 +194,20 @@ limitations under the License.
              ptype="AAA_AUTH_TYPE">
       </PARAM>
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_auth_type ${auth-type}</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Configure the global authentication method to be used to communicate with TACACS+ servers in CONFIGURATION mode. Default is 'pap'.
+          </DESCRIPTION>
+          <USAGE>
+              Configure authentication method in configure mode.
+          </USAGE>
+          <EXAMPLE summary="Configuring global authentication method to use to communicate with tacacs server">
+sonic# configure
+sonic(config)# tacacs-server auth-type
+pap    chap   mschap
+sonic(config)# tacacs-server auth-type chap
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <!-- tacacs secret-key -->
@@ -139,6 +220,20 @@ limitations under the License.
              ptype="TACACS_KEY">
       </PARAM>
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_secret_key ${secret-key}</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Configure the global secret key to be used to authenticate with TACACS+ servers in CONFIGURATION mode.
+          </DESCRIPTION>
+          <USAGE>
+              Configure secret key of 32 characters length to be used in authenticating tacacs server.
+          </USAGE>
+          <EXAMPLE summary="Configuring global secret key to authenticate tacacs server">
+sonic# configure
+sonic(config)# tacacs-server key
+  (Valid Chars: [0-9A-Za-z], Max Len: 32) shared secret
+sonic(config)# tacacs-server key mykey
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <!-- tacacs server -->
@@ -207,6 +302,21 @@ limitations under the License.
       </PARAM>
 
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_tacacs_server ${host} port:${port-val} key:${key-val} timeout:${timeout-val} authtype:${type-val} priority:${priority-val}</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Configure a TACACS+ authentication server in CONFIGURATION mode.
+              Re-enter the tacacs-server host command multiple times to configure more than one TACACS+ server.
+              If configured multiple TACACS+ servers, attempts to connect in the order they were configured.
+              A sonic switch connects with the configured TACACS+ servers one at a time, until a TACACS+ server responds with an accept or reject response.
+          </DESCRIPTION>
+          <USAGE>
+              Configure a tacacs server for authentication in config mode.
+          </USAGE>
+          <EXAMPLE>
+sonic# configure
+sonic(config)# tacacs-server host 3.3.3.3 port 30 timeout 30 key mykey type mschap priority 30
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <!-- no tacacs server -->
@@ -221,26 +331,88 @@ limitations under the License.
              ptype="IPV4V6_ADDR">
       </PARAM>
       <ACTION> python $SONIC_CLI_ROOT/sonic-cli-tacacs.py delete_openconfig_system_system_aaa_server_groups_server_group_servers_server_tacacs_config ${address}</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Delete a configured tacacs host. The command takes ip address of the host.
+          </DESCRIPTION>
+          <USAGE>
+             Unconfigure previously configured tacacs server.
+          </USAGE>
+          <EXAMPLE>
+sonic# configure
+sonic(config)# no tacacs-server host
+  A.B.C.D/A::B  server ip address
+sonic(config)# no tacacs-server host 3.3.3.3
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <COMMAND name="no tacacs-server source-ip"
              help="Unconfigure global source ip for TACACS">
       <ACTION> python $SONIC_CLI_ROOT/sonic-cli-tacacs.py delete_openconfig_system_ext_system_aaa_server_groups_server_group_config_source_address</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Delete configured source IP address from config mode.
+          </DESCRIPTION>
+          <USAGE>
+              Unconfigure previously configured source IP address.
+          </USAGE>
+          <EXAMPLE>
+sonic# configure
+sonic(config)# no tacacs-server source-ip
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <COMMAND name="no tacacs-server timeout"
              help="Unconfigure global timeout for TACACS">
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_timeout 5</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Delete configured timeout from config mode. This operation defaults timeout to five seconds.
+          </DESCRIPTION>
+          <USAGE>
+              Unconfigure previously configured timeout.
+          </USAGE>
+          <EXAMPLE>
+sonic# configure
+sonic(config)# no tacacs-server timeout
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <COMMAND name="no tacacs-server auth-type"
              help="Unconfigure global auth-type for TACACS">
       <ACTION>python $SONIC_CLI_ROOT/sonic-cli-tacacs.py patch_openconfig_system_ext_system_aaa_server_groups_server_group_config_auth_type pap</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Delete configured authentication type from config mode. This operation defaults auth-type to 'pap'.
+          </DESCRIPTION>
+          <USAGE>
+              Unconfigure previously configured authentication method.
+          </USAGE>
+          <EXAMPLE>
+sonic# configure
+sonic(config)# no tacacs-server auth-type
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <COMMAND name="no tacacs-server key"
              help="Unconfigure global shared secret for TACACS">
       <ACTION> python $SONIC_CLI_ROOT/sonic-cli-tacacs.py delete_openconfig_system_ext_system_aaa_server_groups_server_group_config_secret_key</ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Delete configured secret key from config mode.
+          </DESCRIPTION>
+          <USAGE>
+              Unconfigure previously configured secret key.
+          </USAGE>
+          <EXAMPLE>
+sonic# configure
+sonic(config)# no tacacs-server key
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
   </VIEW>

--- a/src/CLI/clitree/cli-xml/tacacs.xml
+++ b/src/CLI/clitree/cli-xml/tacacs.xml
@@ -311,10 +311,13 @@ sonic(config)# tacacs-server key mykey
           </DESCRIPTION>
           <USAGE>
               Configure a tacacs server for authentication in config mode.
+              Default value of Port is 49. Default value of Priority is 1.
+              Default value of timeout is 5. Default value of Type is chap.
           </USAGE>
           <EXAMPLE>
 sonic# configure
 sonic(config)# tacacs-server host 3.3.3.3 port 30 timeout 30 key mykey type mschap priority 30
+sonic(config)# tacacs-server host 4.4.4.4
           </EXAMPLE>
       </DOCGEN>
     </COMMAND>

--- a/src/CLI/clitree/cli-xml/vrf.xml
+++ b/src/CLI/clitree/cli-xml/vrf.xml
@@ -40,12 +40,50 @@ limitations under the License.
                 python $SONIC_CLI_ROOT/sonic-cli-vrf.py get_openconfig_network_instance_network_instances_network_instance show_vrf.j2 ${vrf-name};
             fi
         </ACTION>
+        <DOCGEN>
+            <DESCRIPTION>
+                Display configuration information for a specified VRF and its associated interfaces or
+                all VRF and their associated interfaces.
+            </DESCRIPTION>
+            <USAGE>
+                sonic# show ip vrf
+            </USAGE>
+            <EXAMPLE summary="show all VRF with their associated interfaces">
+                sonic# show ip vrf
+                VRF-NAME            INTERFACES
+                ----------------------------------------------------------------
+                mgmt                eth0
+                Vrf_red             Ethernet16
+                                    Ethernet8
+            </EXAMPLE>
+            <EXAMPLE summary="show a specified VRF with its associated interface">
+                sonic# show ip vrf Vrf_red
+                VRF-NAME            INTERFACES
+                ----------------------------------------------------------------
+                Vrf_red             Ethernet16
+                                    Ethernet8
+            </EXAMPLE>
+        </DOCGEN>
       </COMMAND>
 
       <COMMAND name="show ip vrf management" help="Show management VRF information">
         <ACTION> 
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py get_openconfig_network_instance_network_instances_network_instance show_vrf.j2 "mgmt"
         </ACTION>
+        <DOCGEN>
+            <DESCRIPTION>
+                Display configuration information for management VRF.
+            </DESCRIPTION>
+            <USAGE>
+                sonic# show ip vrf management
+            </USAGE>
+            <EXAMPLE summary="show management VRF">
+                sonic# show ip vrf management
+                VRF-NAME            INTERFACES
+                ----------------------------------------------------------------
+                mgmt                eth0
+            </EXAMPLE>
+        </DOCGEN>
       </COMMAND>
     </VIEW>
 
@@ -55,6 +93,17 @@ limitations under the License.
       <ACTION> 
         python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "True" 
       </ACTION> 
+      <DOCGEN>
+          <DESCRIPTION>
+              Command to configure management VRF.
+          </DESCRIPTION>
+          <USAGE>
+              sonic# ip vrf management
+          </USAGE>
+          <EXAMPLE summary="Configure management VRF">
+              sonic# ip vrf management
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
     
     <COMMAND
@@ -72,6 +121,17 @@ limitations under the License.
       <ACTION>
         python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance ${vrf-name} "L3VRF" "True"
       </ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Command to configure a data VRF.
+          </DESCRIPTION>
+          <USAGE>
+              sonic# ip vrf
+          </USAGE>
+          <EXAMPLE summary="Configure a data VRF">
+              sonic# ip vrf Vrf_red
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <!-- no vrf commands -->
@@ -79,6 +139,17 @@ limitations under the License.
       <ACTION> 
         python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance "mgmt" "L3VRF" "False"  
       </ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Command to delete management VRF.
+          </DESCRIPTION>
+          <USAGE>
+              sonic# no ip vrf management
+          </USAGE>
+          <EXAMPLE summary="Delete management VRF">
+              sonic# no ip vrf management
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     <COMMAND
@@ -96,6 +167,17 @@ limitations under the License.
       <ACTION>
         python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance ${vrf-name} "L3VRF" "False"
       </ACTION>
+      <DOCGEN>
+          <DESCRIPTION>
+              Command to delete a data VRF.
+          </DESCRIPTION>
+          <USAGE>
+              sonic# no ip vrf
+          </USAGE>
+          <EXAMPLE summary="Delete a data VRF">
+              sonic# no ip vrf Vrf_red
+          </EXAMPLE>
+      </DOCGEN>
     </COMMAND>
 
     </VIEW>

--- a/src/CLI/clitree/macro/vrf_macro.xml
+++ b/src/CLI/clitree/macro/vrf_macro.xml
@@ -35,6 +35,17 @@ limitations under the License.
         <ACTION>
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py patch_openconfig_network_instance_network_instances_network_instance_interface ${vrf-name} arg1
         </ACTION>
+        <DOCGEN>
+            <DESCRIPTION>
+                Command to assign a VRF to an interface.
+            </DESCRIPTION>
+            <USAGE>
+                sonic# ip vrf forwarding
+            </USAGE>
+            <EXAMPLE summary="Assign a VRF to an interface">
+                sonic# ip vrf forwarding Vrf_red
+            </EXAMPLE>
+        </DOCGEN>
     </COMMAND>
 
     <COMMAND name="no ip vrf" help="Unbind interface from specified VRF domain"/>
@@ -53,6 +64,17 @@ limitations under the License.
         <ACTION>
           python $SONIC_CLI_ROOT/sonic-cli-vrf.py delete_openconfig_network_instance_network_instances_network_instance_interface ${vrf-name} arg1
         </ACTION>
+        <DOCGEN>
+            <DESCRIPTION>
+                Command to remove the assignment of a VRF to an interface.
+            </DESCRIPTION>
+            <USAGE>
+                sonic# no ip vrf forwarding
+            </USAGE>
+            <EXAMPLE summary="Remove a VRF assignment to an interface">
+                sonic# no ip vrf forwarding Vrf_red
+            </EXAMPLE>
+        </DOCGEN>
     </COMMAND>
 
 </MACRODEF>


### PR DESCRIPTION
This is to cope with click config on mgmt vrf.

Testing:

~~~text
Now:

sonic# show ip vrf
----------------------------------------------------------------
mgmt                eth0
Vrf_blue

After: root@sonic:~# config vrf del mgmt (which disables mgmt VRF, not remove it)

sonic# show ip vrf
----------------------------------------------------------------
Vrf_blue

After: root@sonic:~# config vrf add mgmt (which enables mgmt VRF)

sonic# show ip vrf
----------------------------------------------------------------
mgmt                eth0
Vrf_blue

~~~
