### PR TITLE
Not show disbled mgmt VRF

### DIFF
--- a/src/CLI/renderer/templates/show_vrf.j2
+++ b/src/CLI/renderer/templates/show_vrf.j2
@@ -4,7 +4,9 @@
     {% for vrf_data in json_output %}
         {% for vrf_name,vrf_info in vrf_data.items() %}
             {% if vrf_name == 'mgmt' %}
-                {{-'mgmt'.ljust(20)}}{{'eth0'}}
+                {% if vrf_info['openconfig-network-instance:config']['enabled'] == True %}
+                    {{-'mgmt'.ljust(20)}}{{'eth0'}}
+                {% endif %}
             {% else %}
                 {% set ns = namespace(v_name=vrf_name) %}
                 {% set intfs = vrf_info['openconfig-network-instance:interface'] %}


### PR DESCRIPTION
This is to cope with click config on mgmt VRF

testing:

~~~text
Now:

sonic# show ip vrf
----------------------------------------------------------------
mgmt                eth0
Vrf_blue

After: root@sonic:~# config vrf del mgmt (which disables mgmt VRF, not remove it):

sonic# show ip vrf
----------------------------------------------------------------
Vrf_blue

After: root@sonic:~# config vrf add mgmt (which enables mgmt VRF):

sonic# show ip vrf
----------------------------------------------------------------
mgmt                eth0
Vrf_blue

~~~