### PR TITLE
Handle scenario when interface object doesnt exist

### DIFF
--- a/src/translib/transformer/sw_vlan.go
+++ b/src/translib/transformer/sw_vlan.go
@@ -1246,7 +1246,7 @@ var YangToDb_sw_vlans_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (map[
 
     if intf.Ethernet == nil && intf.Aggregation == nil {
         return nil, errors.New("Wrong Config Request")
-    } 
+    }
     if intf.Ethernet != nil {
         if intf.Ethernet.SwitchedVlan == nil || intf.Ethernet.SwitchedVlan.Config == nil {
             return nil, errors.New("Wrong config request for Ethernet!")
@@ -1630,8 +1630,11 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
 
         intfObj := intfsObj.Interface[ifName]
         if (intfObj == nil) {
-            return nil
+            log.Info("intfObj is nil")
+            intfObj, _ = intfsObj.NewInterface(ifName)
+            ygot.BuildEmptyTree(intfObj)
         }
+
         if intfObj.Ethernet == nil && intfObj.Aggregation == nil {
             return errors.New("Wrong GET request for switched-vlan!")
         }

--- a/src/translib/transformer/sw_vlan.go
+++ b/src/translib/transformer/sw_vlan.go
@@ -27,7 +27,7 @@ import (
     "reflect"
     "strings"
     log "github.com/golang/glog"
-    "github.com/openconfig/ygot/ygot"    
+    "github.com/openconfig/ygot/ygot"
 )
 
 type intfModeType int
@@ -88,7 +88,7 @@ func isLastVlanMemberOnPort (d *db.DB, vlanName *string, ifName *string) bool {
         if(err != nil) {
             log.Infof ("isLastVlanMemberOnPort: err %v when get vlanEntry for vlan %v if %v",
                        err, *vlanName, *ifName)
-            return false 
+            return false
         }
 
         /* if the vlan match the input vlanName, continue with the next vlan */
@@ -102,7 +102,7 @@ func isLastVlanMemberOnPort (d *db.DB, vlanName *string, ifName *string) bool {
             if strings.Contains(members, *ifName) {
                 log.Infof("isLastVlanMemberOnPort: if %v member of vlan %v",
                           *ifName, vlanEntry)
-                return false 
+                return false
             }
         }
     }
@@ -221,8 +221,8 @@ func enableStpOnInterfaceVlanMembership(d *db.DB, vlanName *string, intfList []s
 
         for i, _ := range intfList {
             if !contains(stpVlanPortEnabledIntfList, intfList[i]) {
-                tableKey := *vlanName + "|" + intfList[i] 
-                stpVlanPortMap[tableKey] = defaultStpVlanPortDBValues 
+                tableKey := *vlanName + "|" + intfList[i]
+                stpVlanPortMap[tableKey] = defaultStpVlanPortDBValues
             }
         }
     }
@@ -276,7 +276,7 @@ func removeStpConfigOnVlanDeletion(inParams *XfmrParams, vlanName *string, membe
 }
 
 func removeStpOnInterfaceSwitchportDeletion(d *db.DB, vlanName *string, intfList []string,
-                                            stpVlanPortMap map[string]db.Value, 
+                                            stpVlanPortMap map[string]db.Value,
                                             stpPortMap map[string]db.Value,
                                             isTagged bool) {
 
@@ -568,9 +568,9 @@ func removeTaggedVlanAndUpdateVlanMembTbl(d *db.DB, trunkVlan *string, ifName *s
 }
 
 /* Remove untagged port associated with VLAN and update VLAN_MEMBER table */
-func removeUntaggedVlanAndUpdateVlanMembTbl(d *db.DB, ifName *string, 
+func removeUntaggedVlanAndUpdateVlanMembTbl(d *db.DB, ifName *string,
                                             vlanMemberMap map[string]db.Value,
-                                            stpVlanPortMap map[string]db.Value, 
+                                            stpVlanPortMap map[string]db.Value,
                                             stpPortMap map[string]db.Value) (*string, error) {
     if len(*ifName) == 0 {
         return nil, errors.New("Interface name is empty for fetching list of VLANs!")
@@ -606,7 +606,7 @@ func removeUntaggedVlanAndUpdateVlanMembTbl(d *db.DB, ifName *string,
         vlanName := vlanMember.Get(0)
         vlanMemberKey := vlanName + "|" + *ifName
         if tagMode == "untagged" {
-            vlanMemberMap[vlanMemberKey] = memberPortEntry 
+            vlanMemberMap[vlanMemberKey] = memberPortEntry
             // Disable STP configuration for ports which are removed from VLan membership
             var memberPorts []string
             memberPorts = append(memberPorts, *ifName)
@@ -1205,7 +1205,7 @@ func deleteVlanIntfAndMembers(inParams *XfmrParams, vlanName *string) error {
                 return err
             }
             vlanMemberKey := *vlanName + "|" + memberPort
-            vlanMemberMap[vlanMemberKey] = db.Value{Field:map[string]string{}} 
+            vlanMemberMap[vlanMemberKey] = db.Value{Field:map[string]string{}}
             if err != nil {
                 return err
             }
@@ -1234,7 +1234,7 @@ var YangToDb_sw_vlans_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (map[
     stpPortMap := make(map[string]db.Value)
     log.Info("YangToDb_sw_vlans_xfmr: ", inParams.uri)
 
-    var swVlanConfig swVlanMemberPort_t 
+    var swVlanConfig swVlanMemberPort_t
     pathInfo := NewPathInfo(inParams.uri)
     ifName := pathInfo.Var("name")
 
@@ -1388,10 +1388,10 @@ func getIntfVlanAttr(ifName *string, ifMode intfModeType, vlanMemberMap map[stri
     return nil, nil, nil
 }
 
-func getSpecificSwitchedVlanStateAttr(targetUriPath *string, ifKey *string, 
+func getSpecificSwitchedVlanStateAttr(targetUriPath *string, ifKey *string,
                                       vlanMemberMap map[string]map[string]db.Value,
                                       swVlan *swVlanMemberPort_t, intfType E_InterfaceType) (bool, error) {
-    var config bool = true                                    
+    var config bool = true
     log.Info("Specific Switched-vlan attribute!")
     switch *targetUriPath {
     case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan/state/access-vlan":
@@ -1530,7 +1530,7 @@ func getSwitchedVlanState(ifKey *string, vlanMemberMap map[string]map[string]db.
                 swVlan.swEthMember.Config.AccessVlan = &vlanIdCast
              } else {
                 swVlan.swEthMember.State.AccessVlan = &vlanIdCast
-             }   
+             }
         }
         for _, vlanName := range trunkVlans {
             vlanIdStr := vlanName[len("Vlan"):len(vlanName)]
@@ -1580,17 +1580,17 @@ func getSwitchedVlanState(ifKey *string, vlanMemberMap map[string]map[string]db.
             }
 
             vlanIdCast := uint16(vlanId)
-            if config == true {            
+            if config == true {
                 trunkVlan, _ := swVlan.swPortChannelMember.Config.To_OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_Config_TrunkVlans_Union(vlanIdCast)
                 swVlan.swPortChannelMember.Config.TrunkVlans = append(swVlan.swPortChannelMember.Config.TrunkVlans, trunkVlan)
             } else {
                 trunkVlan, _ := swVlan.swPortChannelMember.State.To_OpenconfigInterfaces_Interfaces_Interface_Aggregation_SwitchedVlan_State_TrunkVlans_Union(vlanIdCast)
-                swVlan.swPortChannelMember.State.TrunkVlans = append(swVlan.swPortChannelMember.State.TrunkVlans, trunkVlan)                
+                swVlan.swPortChannelMember.State.TrunkVlans = append(swVlan.swPortChannelMember.State.TrunkVlans, trunkVlan)
             }
 
         }
     }
-    return nil 
+    return nil
 }
 
 /* Subtree transformer supports GET operation */
@@ -1609,26 +1609,29 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
     log.Infof("Ethernet-Switched Vlan Get observed for Interface: %s", ifName)
     intfType, _, err := getIntfTypeByName(ifName)
     if intfType != IntfTypeEthernet && intfType != IntfTypePortChannel || err != nil {
-    	if intfType == IntfTypeVxlan {
-    		return nil
-    	} else {
-	        intfTypeStr := strconv.Itoa(int(intfType))
-    	    errStr := "TableXfmrFunc - Invalid interface type" + intfTypeStr
-        	log.Error(errStr);
-	        return errors.New(errStr);
-    	}
+        if intfType == IntfTypeVxlan {
+		return nil
+	} else {
+	    intfTypeStr := strconv.Itoa(int(intfType))
+	    errStr := "TableXfmrFunc - Invalid interface type" + intfTypeStr
+	    log.Error(errStr);
+	    return errors.New(errStr);
+	}
     }
 
 
-    if ((strings.Contains(inParams.uri, "ethernet") && (intfType == IntfTypePortChannel)) ||  
+    if ((strings.Contains(inParams.uri, "ethernet") && (intfType == IntfTypePortChannel)) ||
         (strings.Contains(inParams.uri, "aggregation") && (intfType == IntfTypeEthernet))) {
         return nil
-    } 
+    }
 
     targetUriPath, err := getYangPathFromUri(inParams.uri)
     log.Info("targetUriPath is ", targetUriPath)
 
         intfObj := intfsObj.Interface[ifName]
+        if (intfObj == nil) {
+            return nil
+        }
         if intfObj.Ethernet == nil && intfObj.Aggregation == nil {
             return errors.New("Wrong GET request for switched-vlan!")
         }
@@ -1640,7 +1643,7 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
         }
         if intfObj.Aggregation != nil {
             if intfObj.Aggregation.SwitchedVlan == nil {
-                ygot.BuildEmptyTree(intfObj.Aggregation)                
+                ygot.BuildEmptyTree(intfObj.Aggregation)
             }
             swVlan.swPortChannelMember = intfObj.Aggregation.SwitchedVlan
         }
@@ -1683,7 +1686,7 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
                     case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/openconfig-vlan:switched-vlan":
                         fallthrough
                     case "/openconfig-interfaces:interfaces/interface/openconfig-if-ethernet:ethernet/switched-vlan":
-                         fallthrough    
+                         fallthrough
                     case "/openconfig-interfaces:interfaces/interface/ethernet/switched-vlan":
                         err = getSwitchedVlanState(&ifName, vlanMemberMap, &swVlan, intfType, true)
                         if err != nil {
@@ -1714,7 +1717,6 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
                     return err
                 }
                 log.Info("Succesfully completed DB population for Port-Channel!")
-                
                 attrPresent, err := getSpecificSwitchedVlanStateAttr(&targetUriPath, &ifName, vlanMemberMap, &swVlan, intfType)
                 if(err != nil) {
                     return err

--- a/src/translib/transformer/sw_vlan.go
+++ b/src/translib/transformer/sw_vlan.go
@@ -1630,7 +1630,6 @@ var DbToYang_sw_vlans_xfmr SubTreeXfmrDbToYang = func (inParams XfmrParams) (err
 
         intfObj := intfsObj.Interface[ifName]
         if (intfObj == nil) {
-            log.Info("intfObj is nil")
             intfObj, _ = intfsObj.NewInterface(ifName)
             ygot.BuildEmptyTree(intfObj)
         }


### PR DESCRIPTION
While displaying the interfaces while handling switched-vlan get, interfaces object is fetched and individual interface object was tried to fetch other attrs. The interface object was nil ([SNC-4019](https://jira.force10networks.com/browse/SNC-4019)).

When there is no interface object, create new instance and build empty tree .

Tested the following:
From CLI with/without trunk/access switched-vlan:
show interface ethernet
show interface vlan
show interface status

From the swagger with/without trunk/access switched vlan.:
did a get for interfaces/
did a get for interfaces/interface={name}
did a get for interfaces/interface={name}/ethernet
did a get for interfaces/interface={name}/ethernet/switched-vlan/
did a get for interfaces/interface={name}/ethernet/switched-vlan/config/access-vlan
did a get for interfaces/interface={name}/ethernet/switched-vlan/config/trunk-vlan
did a get for interfaces/interface={name}/ethernet/switched-vlan/config/trunk-vlan={vlan-id}


From CLISH cli:
~~~text
sonic# show interface Ethernet
Ethernet0 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet4 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
--more--
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet8 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet12 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet16 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
--more--
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet20 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet24 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet28 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
--more--
Ethernet32 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet36 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet40 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet44 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
--more--
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet48 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet52 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet56 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
--more--
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet60 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet64 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet68 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
--more--
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet72 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet76 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet80 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
--more--
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet84 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet88 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet92 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
--more--
Ethernet96 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet100 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet104 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet108 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
--more--
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet112 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet116 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet120 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
--more--
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
Ethernet124 is down, line protocol is down
Hardware is Eth
Mode of IPV4 address assignment: not-set
Mode of IPV6 address assignment: not-set
IP MTU 9100 bytes
LineSpeed 40GB, Auto-negotiation off
Input statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
        0 Packets (128 to 255 Octects)
Output statistics:
        0 packets, 0 octets
        0 Multicasts, 0 Broadcasts, 0 Unicasts
        0 error, 0 discarded, 0 Oversize
sonic#

~~~

FROM CLICK cli:
~~~text
root@sonic:~# show interfaces  status
  Interface            Lanes    Speed    MTU           Alias    Vlan    Oper    Admin            Type    Asym PFC
-----------  ---------------  -------  -----  --------------  ------  ------  -------  --------------  ----------
  Ethernet0      25,26,27,28      40G   9100    fortyGigE0/0  routed    down     down             N/A         N/A
  Ethernet4      29,30,31,32      40G   9100    fortyGigE0/4  routed    down     down  QSFP+ or later         N/A
  Ethernet8      33,34,35,36      40G   9100    fortyGigE0/8  routed    down     down             N/A         N/A
 Ethernet12      37,38,39,40      40G   9100   fortyGigE0/12  routed    down     down  QSFP+ or later         N/A
 Ethernet16      45,46,47,48      40G   9100   fortyGigE0/16  routed    down     down             N/A         N/A
 Ethernet20      41,42,43,44      40G   9100   fortyGigE0/20  routed    down     down  QSFP+ or later         N/A
 Ethernet24          1,2,3,4      40G   9100   fortyGigE0/24  routed    down     down             N/A         N/A
 Ethernet28          5,6,7,8      40G   9100   fortyGigE0/28  routed    down     down             N/A         N/A
 Ethernet32      13,14,15,16      40G   9100   fortyGigE0/32  routed    down     down             N/A         N/A
 Ethernet36       9,10,11,12      40G   9100   fortyGigE0/36  routed    down     down             N/A         N/A
 Ethernet40      17,18,19,20      40G   9100   fortyGigE0/40  routed    down     down             N/A         N/A
 Ethernet44      21,22,23,24      40G   9100   fortyGigE0/44  routed    down     down             N/A         N/A
 Ethernet48      53,54,55,56      40G   9100   fortyGigE0/48  routed    down     down             N/A         N/A
 Ethernet52      49,50,51,52      40G   9100   fortyGigE0/52  routed    down     down             N/A         N/A
 Ethernet56      57,58,59,60      40G   9100   fortyGigE0/56  routed    down     down  QSFP+ or later         N/A
 Ethernet60      61,62,63,64      40G   9100   fortyGigE0/60  routed    down     down             N/A         N/A
 Ethernet64      69,70,71,72      40G   9100   fortyGigE0/64  routed    down     down             N/A         N/A
 Ethernet68      65,66,67,68      40G   9100   fortyGigE0/68  routed    down     down             N/A         N/A
 Ethernet72      73,74,75,76      40G   9100   fortyGigE0/72  routed    down     down             N/A         N/A
 Ethernet76      77,78,79,80      40G   9100   fortyGigE0/76  routed    down     down             N/A         N/A
 Ethernet80  109,110,111,112      40G   9100   fortyGigE0/80  routed    down     down  QSFP+ or later         N/A
 Ethernet84  105,106,107,108      40G   9100   fortyGigE0/84  routed    down     down  QSFP+ or later         N/A
 Ethernet88  113,114,115,116      40G   9100   fortyGigE0/88  routed    down     down  QSFP+ or later         N/A
 Ethernet92  117,118,119,120      40G   9100   fortyGigE0/92  routed    down     down  QSFP+ or later         N/A
 Ethernet96  125,126,127,128      40G   9100   fortyGigE0/96  routed    down     down             N/A         N/A
Ethernet100  121,122,123,124      40G   9100  fortyGigE0/100  routed    down     down             N/A         N/A
Ethernet104      81,82,83,84      40G   9100  fortyGigE0/104  routed    down     down             N/A         N/A
Ethernet108      85,86,87,88      40G   9100  fortyGigE0/108  routed    down     down             N/A         N/A
Ethernet112      93,94,95,96      40G   9100  fortyGigE0/112  routed    down     down  QSFP+ or later         N/A
Ethernet116      89,90,91,92      40G   9100  fortyGigE0/116  routed    down     down             N/A         N/A
Ethernet120  101,102,103,104      40G   9100  fortyGigE0/120  routed    down     down             N/A         N/A
Ethernet124     97,98,99,100      40G   9100  fortyGigE0/124  routed    down     down             N/A         N/A
root@sonic:~#

~~~