### PR TITLE
Changing ptype of password for username CLI command

### DIFF
--- a/src/CLI/clitree/cli-xml/system.xml
+++ b/src/CLI/clitree/cli-xml/system.xml
@@ -34,7 +34,7 @@
   <VIEW name="configure-view">
     <COMMAND name="username" help="Add new user" ptype="SUBCOMMAND" mode="subcommand">
        <PARAM name="user-name" help="User name string" ptype="STRING"></PARAM>
-           <PARAM name="password" help="Clear text password " ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="passwd" help="Type clear text password string" ptype="STRING"></PARAM>
+           <PARAM name="password" help="Clear text password " ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="passwd" help="Type clear text password string" ptype="PASSWORD_STR"></PARAM>
 		   <PARAM name="role" help="User role" ptype="SUBCOMMAND" mode="subcommand"> <PARAM name="rl" help="User role (admin/operator)" ptype="STRING">
 	       </PARAM>
            </PARAM>


### PR DESCRIPTION
The password type used earlier was a string and some of the special characters were not accepted as input. Changing the ptype to "PASSWORD_STR" will accept all special characters except single quotes , double quotes , comma and question mark. 