### PR TITLE
add not-supported deviation for lldp parameters

### DIFF
--- a/models/yang/extensions/openconfig-interfaces-ext.yang
+++ b/models/yang/extensions/openconfig-interfaces-ext.yang
@@ -3,7 +3,7 @@ module openconfig-interfaces-ext {
     yang-version "1";
 
     // namespace
-    namespace "http://openconfig.net/yang/interfaces/extention";
+    namespace "http://openconfig.net/yang/interfaces/extension";
 
     prefix "oc-intf-ext";
 

--- a/models/yang/extensions/openconfig-lldp-ext.yang
+++ b/models/yang/extensions/openconfig-lldp-ext.yang
@@ -1,0 +1,25 @@
+module openconfig-lldp-ext {
+
+  yang-version "1";
+
+  // namespace
+  namespace "http://openconfig.net/yang/lldp/extention";
+
+  prefix "oc-lldp-ext";
+
+  import openconfig-lldp { prefix oc-lldp; }
+  import openconfig-lldp-types { prefix oc-lldp-types; }
+  import openconfig-interfaces { prefix oc-if; }
+  import ietf-yang-types { prefix yang; }
+  import openconfig-extensions { prefix oc-ext; }
+
+  deviation /oc-lldp:lldp/oc-lldp:config {
+      deviate not-supported;
+  }
+
+  deviation /oc-lldp:lldp/oc-lldp:interfaces/oc-lldp:interface/oc-lldp:config/oc-lldp:enabled {
+      deviate not-supported;
+  }
+}
+
+

--- a/models/yang/extensions/openconfig-lldp-ext.yang
+++ b/models/yang/extensions/openconfig-lldp-ext.yang
@@ -3,15 +3,11 @@ module openconfig-lldp-ext {
   yang-version "1";
 
   // namespace
-  namespace "http://openconfig.net/yang/lldp/extention";
+  namespace "http://openconfig.net/yang/lldp/extension";
 
   prefix "oc-lldp-ext";
 
   import openconfig-lldp { prefix oc-lldp; }
-  import openconfig-lldp-types { prefix oc-lldp-types; }
-  import openconfig-interfaces { prefix oc-if; }
-  import ietf-yang-types { prefix yang; }
-  import openconfig-extensions { prefix oc-ext; }
 
   deviation /oc-lldp:lldp/oc-lldp:config {
       deviate not-supported;

--- a/models/yang/extensions/openconfig-system-ext.yang
+++ b/models/yang/extensions/openconfig-system-ext.yang
@@ -2,7 +2,7 @@ module openconfig-system-ext {
 
     yang-version "1";
 
-    namespace "http://openconfig.net/yang/system/extention";
+    namespace "http://openconfig.net/yang/system/extension";
 
     prefix "oc-sys-ext";
 


### PR DESCRIPTION
LLDP has currently support only for get. Need to deviate config parameters  as not-supported. 
([SNC-3923](https://jira.force10networks.com/browse/SNC-3923))

Added not-supported tag to lldp/config and lldp/interfaces/interface/config/enabled

Tried all show lldp commands through CLI and swagger to make sure nothing is broken.
Swagger does not display lldp/config and lldp/interfaces/interface/config/enabled.

![image](https://user-images.githubusercontent.com/55261736/75077850-c986ed00-54b8-11ea-9192-30dba5ba66df.png)

Tested few basic tests on both system and interfaces yaml through swagger.
configuring tacacs server,
get on few interfaces