### PR TITLE
Usermod functionality

### DIFF
--- a/src/ham/hamd/hamd.cpp
+++ b/src/ham/hamd/hamd.cpp
@@ -271,6 +271,7 @@ static std::string get_full_roles_as_string(const std::vector< std::string > & r
     return ret;
 }
 
+
 /**
  * @brief Delete a user account
  */
@@ -363,6 +364,40 @@ static std::string get_full_roles_as_string(const std::vector< std::string > & r
     ret._2 = rc == 0 ? "" : std_err;
 
     return ret;
+}
+
+/**
+ * @brief Create a new user or modify an existing user
+ *
+ * @param login     User's login name
+ * @param roles     List of roles
+ * @param hashed_pw Hashed password. Must follow usermod's --password
+ *                  syntax.
+ */
+::DBus::Struct< bool, std::string > hamd_c::usermod(const std::string                & login,
+                                                    const std::vector< std::string > & roles,
+                                                    const std::string                & hashed_pw)
+{
+    ::DBus::Struct< bool,       /* success */
+                    std::string /* errmsg */   > ret;
+    struct passwd * pwd = ::getpwnam(login.c_str());
+    if (pwd == nullptr)
+    {   // Add user if it doesn't exist
+    	return useradd(login,roles,hashed_pw);
+
+    }
+    else // User exists so update password and role
+    {
+        ret = passwd(login,hashed_pw);
+        if (ret._1 == true)
+        {
+                return set_roles(login,roles);
+        }
+        else
+        {
+                return ret;
+        }
+    } 
 }
 
 /**

--- a/src/ham/hamd/hamd.cpp
+++ b/src/ham/hamd/hamd.cpp
@@ -382,7 +382,7 @@ static std::string get_full_roles_as_string(const std::vector< std::string > & r
                     std::string /* errmsg */   > ret;
     struct passwd * pwd = ::getpwnam(login.c_str());
     if (pwd == nullptr)
-    {   // Add user if it doesn't exist
+    {   // Add user since it doesn't exist
     	return useradd(login,roles,hashed_pw);
 
     }

--- a/src/ham/hamd/hamd.h
+++ b/src/ham/hamd/hamd.h
@@ -76,6 +76,7 @@ public:
 
     // DBus "accounts" interface
     virtual ::DBus::Struct< bool, std::string > useradd(const std::string& login, const std::vector< std::string >& roles, const std::string& hashed_pw);
+    virtual ::DBus::Struct< bool, std::string > usermod(const std::string& login, const std::vector< std::string >& roles, const std::string& hashed_pw);
     virtual ::DBus::Struct< bool, std::string > userdel(const std::string& login);
     virtual ::DBus::Struct< bool, std::string > passwd(const std::string& login, const std::string& hashed_pw);
     virtual ::DBus::Struct< bool, std::string > set_roles(const std::string& login, const std::vector< std::string >& roles);

--- a/src/ham/shared/org.SONiC.HostAccountManagement.xml
+++ b/src/ham/shared/org.SONiC.HostAccountManagement.xml
@@ -23,6 +23,12 @@
           <arg direction="in"  type="s"  name="hashed_pw"/>             <!-- This must follow the password syntax used for /etc/shadow -->
           <arg direction="out" type="(bs)" name="(success, errmsg)" />
       </method>
+      <method name="usermod">                                           <!-- See http://man7.org/linux/man-pages/man8/useradd.8.html -->
+          <arg direction="in"  type="s"  name="login"/>                 <!-- User's login Name -->
+          <arg direction="in"  type="as" name="roles"/>                 <!-- Must be a list of existing groups (/etc/group) otherwise the API will return an error -->
+          <arg direction="in"  type="s"  name="hashed_pw"/>             <!-- This must follow the password syntax used for /etc/shadow -->
+          <arg direction="out" type="(bs)" name="(success, errmsg)" />
+      </method>
       <method name="userdel">                                           <!-- See http://man7.org/linux/man-pages/man8/userdel.8.html -->
           <arg direction="in"  type="s"  name="login"/>                 <!-- User's login Name -->
           <arg direction="out" type="(bs)" name="(success, errmsg)" />

--- a/src/translib/transformer/host_acct_mgr.go
+++ b/src/translib/transformer/host_acct_mgr.go
@@ -66,6 +66,21 @@ func hostAccountUserAdd(login, role, hashed_pw string) (bool, string) {
 	return hostAccountParseCallReturn(obj.Call(dest, 0, login, roles, hashed_pw))
 }
 
+// hostAccountUserMod calls the HAM usermod function over D-Bus
+func hostAccountUserMod(login, role, hashed_pw string) (bool, string) {
+        obj, dest, err := hostAccountCallObject("usermod")
+        if err != nil {
+                return false, err.Error()
+        }
+
+        roles := roleToGroup(role)
+        if len(roles) == 0 {
+                return false, fmt.Sprintf("Invalid role %s", role)
+        }
+
+        return hostAccountParseCallReturn(obj.Call(dest, 0, login, roles, hashed_pw))
+}
+
 // hostAccountUserDel calls the HAM userdel over D-Bus
 func hostAccountUserDel(login string) (bool, string) {
 	obj, dest, err := hostAccountCallObject("userdel")

--- a/src/translib/transformer/xfmr_system.go
+++ b/src/translib/transformer/xfmr_system.go
@@ -357,7 +357,7 @@ var YangToDb_sys_aaa_auth_xfmr SubTreeXfmrYangToDb = func(inParams XfmrParams) (
 	    log.Info("User:",*(value.Config.Username))
 	    temp := value.Config.Role.(*ocbinds.OpenconfigSystem_System_Aaa_Authentication_Users_User_Config_Role_Union_String)
 	    log.Info("Role:",temp.String)
-            status, err_str = hostAccountUserAdd(*(value.Config.Username), temp.String, *(value.Config.PasswordHashed))
+            status, err_str = hostAccountUserMod(*(value.Config.Username), temp.String, *(value.Config.PasswordHashed))
         }
     }
 	if (!status) {


### PR DESCRIPTION
I added changes that allow the password and or role of a user to be modified after initial creation of that user.

~~~
admin@sonic:~$ sonic-cli
sonic# configure terminal
sonic(config)# username abc password 123abc role admin
sonic(config)# username abc password 123abc role operator
sonic(config)# username abc password 123xyz role operator
sonic(config)# username abc password 321xyz role admin
sonic(config)# no username abc
~~~
[usermod_syslog.txt](https://github.com/project-arlo/sonic-mgmt-framework/files/4246284/usermod_syslog.txt)
[spytest.txt](https://github.com/project-arlo/sonic-mgmt-framework/files/4247381/spytest.txt)
